### PR TITLE
Fix orientation flickering with directional hysteresis

### DIFF
--- a/app/src/main/java/com/haptictrack/camera/DeviceOrientationListener.kt
+++ b/app/src/main/java/com/haptictrack/camera/DeviceOrientationListener.kt
@@ -13,6 +13,15 @@ import android.view.Surface
  */
 class DeviceOrientationListener(context: Context) {
 
+    companion object {
+        /**
+         * Hysteresis margin in degrees. To leave the current orientation, the
+         * sensor must read past the midpoint (45°) by this many degrees.
+         * Creates a dead zone of 2×HYSTERESIS degrees at each boundary.
+         */
+        const val HYSTERESIS = 20
+    }
+
     /** Current device rotation in degrees: 0, 90, 180, or 270. */
     @Volatile
     var deviceRotation: Int = 0
@@ -31,15 +40,7 @@ class DeviceOrientationListener(context: Context) {
     private val listener = object : OrientationEventListener(context) {
         override fun onOrientationChanged(orientation: Int) {
             if (orientation == ORIENTATION_UNKNOWN) return
-
-            // Snap to nearest 90° bucket with hysteresis
-            deviceRotation = when (orientation) {
-                in 0..44, in 316..359 -> 0
-                in 45..134 -> 90
-                in 135..224 -> 180
-                in 225..315 -> 270
-                else -> 0
-            }
+            deviceRotation = snapWithHysteresis(orientation, deviceRotation)
         }
     }
 
@@ -51,5 +52,37 @@ class DeviceOrientationListener(context: Context) {
 
     fun stop() {
         listener.disable()
+    }
+}
+
+/**
+ * Snap raw orientation to 0/90/180/270 with directional hysteresis.
+ *
+ * Once in a state, the sensor must move [DeviceOrientationListener.HYSTERESIS]
+ * degrees past the midpoint before switching. This prevents flickering when
+ * the phone is held near a boundary (e.g. ~45°).
+ *
+ * Package-level for testability.
+ */
+internal fun snapWithHysteresis(orientation: Int, current: Int): Int {
+    val h = DeviceOrientationListener.HYSTERESIS
+    // Check if we're still within the sticky range of the current orientation.
+    // The sticky range is wider than the entry range by HYSTERESIS on each side.
+    val inCurrent = when (current) {
+        0   -> orientation in 0..(45 + h) || orientation in (315 - h)..359
+        90  -> orientation in (45 - h)..(135 + h)
+        180 -> orientation in (135 - h)..(225 + h)
+        270 -> orientation in (225 - h)..(315 + h)
+        else -> false
+    }
+    if (inCurrent) return current
+
+    // Outside the sticky range — commit to whichever quadrant center is nearest
+    return when (orientation) {
+        in 0..(45 - h), in (315 + h)..359 -> 0
+        in (45 + h)..(135 - h) -> 90
+        in (135 + h)..(225 - h) -> 180
+        in (225 + h)..(315 - h) -> 270
+        else -> current  // in dead zone between quadrants, keep current
     }
 }

--- a/app/src/test/java/com/haptictrack/camera/OrientationHysteresisTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/OrientationHysteresisTest.kt
@@ -1,0 +1,108 @@
+package com.haptictrack.camera
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class OrientationHysteresisTest {
+
+    @Test
+    fun `stays at 0 when near boundary`() {
+        // At 50° — past the 45° midpoint but within 45+20=65° sticky range
+        assertEquals(0, snapWithHysteresis(50, current = 0))
+        assertEquals(0, snapWithHysteresis(60, current = 0))
+        assertEquals(0, snapWithHysteresis(64, current = 0))
+    }
+
+    @Test
+    fun `switches from 0 to 90 when well past boundary`() {
+        // At 70° — past the 65° sticky range, into the 90° entry zone
+        assertEquals(90, snapWithHysteresis(70, current = 0))
+        assertEquals(90, snapWithHysteresis(90, current = 0))
+    }
+
+    @Test
+    fun `stays at 90 when near boundary with 0`() {
+        // At 30° — below 45° midpoint but within 45-20=25° sticky range
+        assertEquals(90, snapWithHysteresis(30, current = 90))
+        assertEquals(90, snapWithHysteresis(26, current = 90))
+    }
+
+    @Test
+    fun `switches from 90 to 0 when well past boundary`() {
+        // At 20° — below the 25° sticky range
+        assertEquals(0, snapWithHysteresis(20, current = 90))
+        assertEquals(0, snapWithHysteresis(10, current = 90))
+    }
+
+    @Test
+    fun `stays at 0 when near 270 boundary`() {
+        // At 300° — within 315-20=295° sticky range
+        assertEquals(0, snapWithHysteresis(300, current = 0))
+        assertEquals(0, snapWithHysteresis(296, current = 0))
+    }
+
+    @Test
+    fun `switches from 0 to 270 when well past boundary`() {
+        assertEquals(270, snapWithHysteresis(290, current = 0))
+    }
+
+    @Test
+    fun `dead zone keeps current state`() {
+        // Exactly at the boundary region between sticky zones
+        // At 65° — right at the edge, still sticky for 0
+        assertEquals(0, snapWithHysteresis(65, current = 0))
+        // At 25° — right at the edge, still sticky for 90
+        assertEquals(90, snapWithHysteresis(25, current = 90))
+    }
+
+    @Test
+    fun `180 stays when near boundaries`() {
+        // 180° sticky range: 135-20=115 to 225+20=245
+        assertEquals(180, snapWithHysteresis(120, current = 180))
+        assertEquals(180, snapWithHysteresis(240, current = 180))
+    }
+
+    @Test
+    fun `180 switches when far past boundaries`() {
+        assertEquals(90, snapWithHysteresis(110, current = 180))
+        assertEquals(270, snapWithHysteresis(250, current = 180))
+    }
+
+    @Test
+    fun `270 stays when near boundaries`() {
+        // 270° sticky range: 225-20=205 to 315+20=335
+        assertEquals(270, snapWithHysteresis(210, current = 270))
+        assertEquals(270, snapWithHysteresis(330, current = 270))
+    }
+
+    @Test
+    fun `exact cardinal directions are stable`() {
+        assertEquals(0, snapWithHysteresis(0, current = 0))
+        assertEquals(90, snapWithHysteresis(90, current = 90))
+        assertEquals(180, snapWithHysteresis(180, current = 180))
+        assertEquals(270, snapWithHysteresis(270, current = 270))
+    }
+
+    @Test
+    fun `rapid oscillation around 45 does not flicker`() {
+        // Simulate accelerometer jitter around 45°
+        var current = 0
+        val readings = listOf(44, 46, 43, 47, 44, 48, 42, 46, 45, 44)
+        for (reading in readings) {
+            current = snapWithHysteresis(reading, current)
+        }
+        // Should stay at 0 the whole time — none of these reach 65°
+        assertEquals(0, current)
+    }
+
+    @Test
+    fun `deliberate rotation transitions correctly`() {
+        // Simulate a smooth rotation from 0° to 90°
+        var current = 0
+        val readings = listOf(10, 20, 30, 40, 50, 60, 70, 80, 90)
+        for (reading in readings) {
+            current = snapWithHysteresis(reading, current)
+        }
+        assertEquals(90, current)
+    }
+}


### PR DESCRIPTION
## Summary

- Add ±20° dead zone to `DeviceOrientationListener` so the phone must rotate 20° past the midpoint before committing to a new orientation
- Prevents flickering when holding the phone near 45°/135°/225°/315° boundaries
- Extract `snapWithHysteresis()` as testable package-level function

## Problem

Holding the phone at ~45° caused rapid alternation between 0° and 90° on every accelerometer reading. The detector saw alternating image orientations, destabilizing bounding boxes and breaking visual tracker cross-checking.

## How it works

| Current state | Stays until | Then switches to |
|---|---|---|
| 0° | sensor passes 65° | 90° |
| 90° | sensor drops below 25° | 0° |

The 40° dead zone (25°–65°) is sticky — whichever state you were in, stays.

## Test plan

- [x] 13 unit tests: boundary behavior, dead zones, jitter simulation, all quadrants
- [ ] Device test: hold phone near 45° and verify no green box flicker

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)