### PR TITLE
Reduce bitmap allocation during debug frame capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 Hands-free camera tracking Android app. Uses on-device object detection + haptic feedback + auto-zoom to let you film a subject without looking at the screen.
 
+## Development Workflow
+
+All changes follow this flow — never commit directly to master:
+
+1. **Branch** — create a feature/fix branch from master
+2. **PR** — push and open a pull request
+3. **Device test** — build, install via ADB, test on physical device
+4. **Review** — review the PR (code review or self-review)
+5. **Merge** — merge to master and delete the branch
+
 ## Quick Reference
 
 ```bash

--- a/app/src/main/java/com/haptictrack/tracking/DebugFrameCapture.kt
+++ b/app/src/main/java/com/haptictrack/tracking/DebugFrameCapture.kt
@@ -103,7 +103,10 @@ class DebugFrameCapture(context: Context) {
     ) {
         val dir = outputDir ?: return
 
-        val annotated = bitmap.copy(Bitmap.Config.ARGB_8888, true) ?: return
+        // Draw annotations onto a mutable copy. The caller (ObjectTracker)
+        // has already saved lastFrameBitmap, so we don't need a third bitmap.
+        val annotated = if (bitmap.isMutable) bitmap
+            else bitmap.copy(Bitmap.Config.ARGB_8888, true) ?: return
         val canvas = Canvas(annotated)
         val w = bitmap.width.toFloat()
         val h = bitmap.height.toFloat()
@@ -142,7 +145,8 @@ class DebugFrameCapture(context: Context) {
         } catch (e: Exception) {
             Log.w(TAG, "Failed to save debug frame: ${e.message}")
         } finally {
-            annotated.recycle()
+            // Only recycle if we allocated the copy ourselves
+            if (annotated !== bitmap) annotated.recycle()
         }
 
         pruneOldFiles(dir)

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -196,6 +196,13 @@ class ObjectTracker(
                 visualTracker.init(bitmap, lockedObject.boundingBox)
             }
 
+            // Save lastFrameBitmap before debug capture to avoid a third bitmap copy.
+            // Debug capture draws annotations directly onto a mutable copy of this frame.
+            synchronized(lastFrameLock) {
+                lastFrameBitmap?.recycle()
+                lastFrameBitmap = bitmap.copy(bitmap.config ?: Bitmap.Config.ARGB_8888, false)
+            }
+
             // Debug frame capture on tracking events
             captureDebugFrame(bitmap, withEmbeddings, lockedObject, wasSearching, prevLost)
 
@@ -203,12 +210,6 @@ class ObjectTracker(
             val displayObjects = filter.filter(withEmbeddings)
 
             onDetectionResult?.invoke(displayObjects, lockedObject, frameWidth, frameHeight)
-
-            // Keep a copy of the frame for embedding on tap-to-lock
-            synchronized(lastFrameLock) {
-                lastFrameBitmap?.recycle()
-                lastFrameBitmap = bitmap.copy(bitmap.config ?: Bitmap.Config.ARGB_8888, false)
-            }
         } finally {
             imageProxy.close()
             bitmap.recycle()


### PR DESCRIPTION
## Summary

- Reorder `ObjectTracker.processImage` to save `lastFrameBitmap` before debug capture
- `DebugFrameCapture.capture()` draws annotations directly onto the passed bitmap when mutable, avoiding a third copy
- Peak allocation during debug capture drops from ~24MB (3 bitmaps) to ~16MB (2 bitmaps)
- Add development workflow section to CLAUDE.md

## Before

```
bitmap (8MB) → captureDebugFrame → bitmap.copy() (8MB)  ← 3rd allocation
                                 → lastFrameBitmap copy (8MB)
```

## After

```
bitmap (8MB) → lastFrameBitmap copy (8MB)
             → captureDebugFrame draws on bitmap directly  ← no 3rd allocation
```

## Test plan

- [x] 105 unit tests pass
- [x] Device test: lock, pan away, pan back — verify debug frames still save correctly

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)