### PR TITLE
Two-stage detection: EfficientDet + YOLOv8n-oiv7 label enrichment

### DIFF
--- a/app/src/main/assets/oiv7_labels.txt
+++ b/app/src/main/assets/oiv7_labels.txt
@@ -1,0 +1,601 @@
+Accordion
+Adhesive tape
+Aircraft
+Airplane
+Alarm clock
+Alpaca
+Ambulance
+Animal
+Ant
+Antelope
+Apple
+Armadillo
+Artichoke
+Auto part
+Axe
+Backpack
+Bagel
+Baked goods
+Balance beam
+Ball
+Balloon
+Banana
+Band-aid
+Banjo
+Barge
+Barrel
+Baseball bat
+Baseball glove
+Bat (Animal)
+Bathroom accessory
+Bathroom cabinet
+Bathtub
+Beaker
+Bear
+Bed
+Bee
+Beehive
+Beer
+Beetle
+Bell pepper
+Belt
+Bench
+Bicycle
+Bicycle helmet
+Bicycle wheel
+Bidet
+Billboard
+Billiard table
+Binoculars
+Bird
+Blender
+Blue jay
+Boat
+Bomb
+Book
+Bookcase
+Boot
+Bottle
+Bottle opener
+Bow and arrow
+Bowl
+Bowling equipment
+Box
+Boy
+Brassiere
+Bread
+Briefcase
+Broccoli
+Bronze sculpture
+Brown bear
+Building
+Bull
+Burrito
+Bus
+Bust
+Butterfly
+Cabbage
+Cabinetry
+Cake
+Cake stand
+Calculator
+Camel
+Camera
+Can opener
+Canary
+Candle
+Candy
+Cannon
+Canoe
+Cantaloupe
+Car
+Carnivore
+Carrot
+Cart
+Cassette deck
+Castle
+Cat
+Cat furniture
+Caterpillar
+Cattle
+Ceiling fan
+Cello
+Centipede
+Chainsaw
+Chair
+Cheese
+Cheetah
+Chest of drawers
+Chicken
+Chime
+Chisel
+Chopsticks
+Christmas tree
+Clock
+Closet
+Clothing
+Coat
+Cocktail
+Cocktail shaker
+Coconut
+Coffee
+Coffee cup
+Coffee table
+Coffeemaker
+Coin
+Common fig
+Common sunflower
+Computer keyboard
+Computer monitor
+Computer mouse
+Container
+Convenience store
+Cookie
+Cooking spray
+Corded phone
+Cosmetics
+Couch
+Countertop
+Cowboy hat
+Crab
+Cream
+Cricket ball
+Crocodile
+Croissant
+Crown
+Crutch
+Cucumber
+Cupboard
+Curtain
+Cutting board
+Dagger
+Dairy Product
+Deer
+Desk
+Dessert
+Diaper
+Dice
+Digital clock
+Dinosaur
+Dishwasher
+Dog
+Dog bed
+Doll
+Dolphin
+Door
+Door handle
+Doughnut
+Dragonfly
+Drawer
+Dress
+Drill (Tool)
+Drink
+Drinking straw
+Drum
+Duck
+Dumbbell
+Eagle
+Earrings
+Egg (Food)
+Elephant
+Envelope
+Eraser
+Face powder
+Facial tissue holder
+Falcon
+Fashion accessory
+Fast food
+Fax
+Fedora
+Filing cabinet
+Fire hydrant
+Fireplace
+Fish
+Flag
+Flashlight
+Flower
+Flowerpot
+Flute
+Flying disc
+Food
+Food processor
+Football
+Football helmet
+Footwear
+Fork
+Fountain
+Fox
+French fries
+French horn
+Frog
+Fruit
+Frying pan
+Furniture
+Garden Asparagus
+Gas stove
+Giraffe
+Girl
+Glasses
+Glove
+Goat
+Goggles
+Goldfish
+Golf ball
+Golf cart
+Gondola
+Goose
+Grape
+Grapefruit
+Grinder
+Guacamole
+Guitar
+Hair dryer
+Hair spray
+Hamburger
+Hammer
+Hamster
+Hand dryer
+Handbag
+Handgun
+Harbor seal
+Harmonica
+Harp
+Harpsichord
+Hat
+Headphones
+Heater
+Hedgehog
+Helicopter
+Helmet
+High heels
+Hiking equipment
+Hippopotamus
+Home appliance
+Honeycomb
+Horizontal bar
+Horse
+Hot dog
+House
+Houseplant
+Human arm
+Human beard
+Human body
+Human ear
+Human eye
+Human face
+Human foot
+Human hair
+Human hand
+Human head
+Human leg
+Human mouth
+Human nose
+Humidifier
+Ice cream
+Indoor rower
+Infant bed
+Insect
+Invertebrate
+Ipod
+Isopod
+Jacket
+Jacuzzi
+Jaguar (Animal)
+Jeans
+Jellyfish
+Jet ski
+Jug
+Juice
+Kangaroo
+Kettle
+Kitchen & dining room table
+Kitchen appliance
+Kitchen knife
+Kitchen utensil
+Kitchenware
+Kite
+Knife
+Koala
+Ladder
+Ladle
+Ladybug
+Lamp
+Land vehicle
+Lantern
+Laptop
+Lavender (Plant)
+Lemon
+Leopard
+Light bulb
+Light switch
+Lighthouse
+Lily
+Limousine
+Lion
+Lipstick
+Lizard
+Lobster
+Loveseat
+Luggage and bags
+Lynx
+Magpie
+Mammal
+Man
+Mango
+Maple
+Maracas
+Marine invertebrates
+Marine mammal
+Measuring cup
+Mechanical fan
+Medical equipment
+Microphone
+Microwave oven
+Milk
+Miniskirt
+Mirror
+Missile
+Mixer
+Mixing bowl
+Mobile phone
+Monkey
+Moths and butterflies
+Motorcycle
+Mouse
+Muffin
+Mug
+Mule
+Mushroom
+Musical instrument
+Musical keyboard
+Nail (Construction)
+Necklace
+Nightstand
+Oboe
+Office building
+Office supplies
+Orange
+Organ (Musical Instrument)
+Ostrich
+Otter
+Oven
+Owl
+Oyster
+Paddle
+Palm tree
+Pancake
+Panda
+Paper cutter
+Paper towel
+Parachute
+Parking meter
+Parrot
+Pasta
+Pastry
+Peach
+Pear
+Pen
+Pencil case
+Pencil sharpener
+Penguin
+Perfume
+Person
+Personal care
+Personal flotation device
+Piano
+Picnic basket
+Picture frame
+Pig
+Pillow
+Pineapple
+Pitcher (Container)
+Pizza
+Pizza cutter
+Plant
+Plastic bag
+Plate
+Platter
+Plumbing fixture
+Polar bear
+Pomegranate
+Popcorn
+Porch
+Porcupine
+Poster
+Potato
+Power plugs and sockets
+Pressure cooker
+Pretzel
+Printer
+Pumpkin
+Punching bag
+Rabbit
+Raccoon
+Racket
+Radish
+Ratchet (Device)
+Raven
+Rays and skates
+Red panda
+Refrigerator
+Remote control
+Reptile
+Rhinoceros
+Rifle
+Ring binder
+Rocket
+Roller skates
+Rose
+Rugby ball
+Ruler
+Salad
+Salt and pepper shakers
+Sandal
+Sandwich
+Saucer
+Saxophone
+Scale
+Scarf
+Scissors
+Scoreboard
+Scorpion
+Screwdriver
+Sculpture
+Sea lion
+Sea turtle
+Seafood
+Seahorse
+Seat belt
+Segway
+Serving tray
+Sewing machine
+Shark
+Sheep
+Shelf
+Shellfish
+Shirt
+Shorts
+Shotgun
+Shower
+Shrimp
+Sink
+Skateboard
+Ski
+Skirt
+Skull
+Skunk
+Skyscraper
+Slow cooker
+Snack
+Snail
+Snake
+Snowboard
+Snowman
+Snowmobile
+Snowplow
+Soap dispenser
+Sock
+Sofa bed
+Sombrero
+Sparrow
+Spatula
+Spice rack
+Spider
+Spoon
+Sports equipment
+Sports uniform
+Squash (Plant)
+Squid
+Squirrel
+Stairs
+Stapler
+Starfish
+Stationary bicycle
+Stethoscope
+Stool
+Stop sign
+Strawberry
+Street light
+Stretcher
+Studio couch
+Submarine
+Submarine sandwich
+Suit
+Suitcase
+Sun hat
+Sunglasses
+Surfboard
+Sushi
+Swan
+Swim cap
+Swimming pool
+Swimwear
+Sword
+Syringe
+Table
+Table tennis racket
+Tablet computer
+Tableware
+Taco
+Tank
+Tap
+Tart
+Taxi
+Tea
+Teapot
+Teddy bear
+Telephone
+Television
+Tennis ball
+Tennis racket
+Tent
+Tiara
+Tick
+Tie
+Tiger
+Tin can
+Tire
+Toaster
+Toilet
+Toilet paper
+Tomato
+Tool
+Toothbrush
+Torch
+Tortoise
+Towel
+Tower
+Toy
+Traffic light
+Traffic sign
+Train
+Training bench
+Treadmill
+Tree
+Tree house
+Tripod
+Trombone
+Trousers
+Truck
+Trumpet
+Turkey
+Turtle
+Umbrella
+Unicycle
+Van
+Vase
+Vegetable
+Vehicle
+Vehicle registration plate
+Violin
+Volleyball (Ball)
+Waffle
+Waffle iron
+Wall clock
+Wardrobe
+Washing machine
+Waste container
+Watch
+Watercraft
+Watermelon
+Weapon
+Whale
+Wheel
+Wheelchair
+Whisk
+Whiteboard
+Willow
+Window
+Window blind
+Wine
+Wine glass
+Wine rack
+Winter melon
+Wok
+Woman
+Wood-burning stove
+Woodpecker
+Worm
+Wrench
+Zebra
+Zucchini

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -26,6 +26,7 @@ class ObjectTracker(
 ) {
 
     private val detector: ObjectDetector
+    private val labelEnricher: Yolov8Detector = Yolov8Detector(context)
 
     // Keep last frame for computing embedding when user taps to lock
     private val lastFrameLock = Any()
@@ -79,22 +80,25 @@ class ObjectTracker(
                 return
             }
 
+            // Enrich coarse COCO label with finer OIV7 label (one-shot, ~270ms)
+            val enrichedLabel = labelEnricher.enrichLabel(bmp, boundingBox, label) ?: label
+
             val augResult = appearanceEmbedder.embedWithAugmentations(bmp, boundingBox)
             // Compute color histogram on the masked crop (single segmentation pass)
             val colorHist = if (augResult.maskedCrop != null) {
                 val fullBox = RectF(0f, 0f, 1f, 1f) // crop is already the object
                 computeColorHistogram(augResult.maskedCrop, fullBox).also { augResult.maskedCrop.recycle() }
             } else computeColorHistogram(bmp, boundingBox)
-            // Classify person attributes at lock time
+            // Classify person attributes at lock time (use original COCO label for "person" check)
             val personAttrs = personClassifier.classify(bmp, boundingBox, label)
-            reacquisition.lock(trackingId, boundingBox, label, augResult.embeddings, colorHist, personAttrs)
+            reacquisition.lock(trackingId, boundingBox, enrichedLabel, augResult.embeddings, colorHist, personAttrs)
             visualTracker.init(bmp, boundingBox)
 
-            debugCapture.startSession(label, trackingId)
+            debugCapture.startSession(enrichedLabel, trackingId)
             val attrStr = personAttrs?.summary() ?: "n/a"
-            debugCapture.log("LOCK id=$trackingId label=$label box=${boundingBox} gallery=${augResult.embeddings.size} colorHist=${colorHist != null} attrs=\"$attrStr\"")
+            debugCapture.log("LOCK id=$trackingId label=$enrichedLabel (coco=$label) box=${boundingBox} gallery=${augResult.embeddings.size} colorHist=${colorHist != null} attrs=\"$attrStr\"")
 
-            val locked = TrackedObject(trackingId, boundingBox, label)
+            val locked = TrackedObject(trackingId, boundingBox, enrichedLabel)
             debugCapture.capture(DebugEvent.LOCK, bmp, listOf(locked), lockedObject = locked,
                 extraInfo = "id=$trackingId label=$label gallery=${augResult.embeddings.size}")
         }
@@ -220,9 +224,22 @@ class ObjectTracker(
             // handoff). Without embeddings, two same-label objects are indistinguishable.
             val needEmbeddings = reacquisition.hasEmbeddings &&
                 (reacquisition.isSearching || (reacquisition.isLocked && reacquisition.framesLost == 0))
+
+            // Enrich labels with YOLOv8 during search (every 10 frames, not every frame)
+            val searchFrame = reacquisition.framesLost
+            val shouldEnrichLabels = reacquisition.isSearching && tracked.isNotEmpty() &&
+                (searchFrame <= 1 || searchFrame % 10 == 0)
+            val enrichedIds = if (shouldEnrichLabels) labelEnricher.enrichLabels(bitmap, tracked) else emptyMap()
+            val withLabels = if (enrichedIds.isNotEmpty()) {
+                tracked.map { obj ->
+                    val enriched = enrichedIds[obj.id]
+                    if (enriched != null) obj.copy(label = enriched) else obj
+                }
+            } else tracked
+
             val withEmbeddings = if (needEmbeddings) {
                 // First pass: compute embeddings + histograms for all candidates
-                val withVisual = tracked.map { obj ->
+                val withVisual = withLabels.map { obj ->
                     val result = appearanceEmbedder.embedAndCrop(bitmap, obj.boundingBox)
                     val hist = if (result.maskedCrop != null) {
                         val fullBox = RectF(0f, 0f, 1f, 1f)
@@ -244,7 +261,7 @@ class ObjectTracker(
                         obj.copy(personAttributes = attrs)
                     } else obj
                 }
-            } else tracked
+            } else withLabels
 
             // Snapshot state before processing
             val wasSearching = reacquisition.isSearching
@@ -403,6 +420,8 @@ class ObjectTracker(
     fun shutdown() {
         debugCapture.endSession()
         detector.close()
+        labelEnricher.close()
+        personClassifier.shutdown()
         appearanceEmbedder.shutdown()
         visualTracker.stop()
         synchronized(lastFrameLock) {

--- a/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
@@ -32,6 +32,8 @@ class ReacquisitionEngine(
         const val APPEARANCE_OVERRIDE_THRESHOLD = 0.7f
         /** Maximum embeddings to keep in gallery. */
         const val MAX_GALLERY_SIZE = 12
+        /** Max times we re-acquire different objects before giving up. */
+        const val MAX_REACQUISITION_HOPS = 3
     }
 
     var lockedId: Int? = null
@@ -58,6 +60,9 @@ class ReacquisitionEngine(
         private set
     var framesLost: Int = 0
         private set
+    /** Number of times we've re-acquired a different object since the original lock. */
+    var reacquisitionHops: Int = 0
+        private set
 
     val isLocked: Boolean get() = lockedId != null
     val isSearching: Boolean get() = lockedId != null && framesLost > 0 && framesLost <= maxFramesLost
@@ -78,6 +83,7 @@ class ReacquisitionEngine(
         lastKnownLabel = label
         lastKnownSize = boundingBox.width() * boundingBox.height()
         framesLost = 0
+        reacquisitionHops = 0
         val attrStr = personAttrs?.summary() ?: "n/a"
         dualLog(Log.INFO, "LOCK id=$trackingId label=\"$label\" box=${fmtBox(boundingBox)} size=${fmtF(lastKnownSize)} gallery=${embeddingGallery.size} colorHist=${colorHist != null} attrs=\"$attrStr\"")
     }
@@ -106,6 +112,7 @@ class ReacquisitionEngine(
         lastKnownLabel = null
         lastKnownSize = 0f
         framesLost = 0
+        reacquisitionHops = 0
     }
 
     fun processFrame(detections: List<TrackedObject>): TrackedObject? {
@@ -126,9 +133,13 @@ class ReacquisitionEngine(
         if (framesLost == 1) {
             dualLog(Log.WARN, "LOST id=$lockId (lockedLabel=\"$lockedLabel\") — starting search. ${detections.size} candidates in frame")
         }
-        if (framesLost > maxFramesLost) {
+        if (framesLost > maxFramesLost || reacquisitionHops >= MAX_REACQUISITION_HOPS) {
             if (framesLost == maxFramesLost + 1) {
                 dualLog(Log.WARN, "TIMEOUT after $maxFramesLost frames. Giving up on lockedLabel=\"$lockedLabel\"")
+            }
+            if (reacquisitionHops >= MAX_REACQUISITION_HOPS && framesLost == 1) {
+                dualLog(Log.WARN, "GIVE_UP after $reacquisitionHops re-acquisition hops — original object is gone")
+                framesLost = maxFramesLost + 1  // force timeout state
             }
             return null
         }
@@ -146,7 +157,8 @@ class ReacquisitionEngine(
 
         val reacquired = findBestCandidate(detections)
         if (reacquired != null) {
-            dualLog(Log.INFO, "REACQUIRE id=${reacquired.id} label=\"${reacquired.label}\" after $framesLost frames (lockedLabel=\"$lockedLabel\") box=${fmtBox(reacquired.boundingBox)}")
+            reacquisitionHops++
+            dualLog(Log.INFO, "REACQUIRE id=${reacquired.id} label=\"${reacquired.label}\" after $framesLost frames (lockedLabel=\"$lockedLabel\") hop=$reacquisitionHops/${MAX_REACQUISITION_HOPS} box=${fmtBox(reacquired.boundingBox)}")
             lockedId = reacquired.id
             updateFromMatch(reacquired)
             return reacquired
@@ -271,7 +283,13 @@ class ReacquisitionEngine(
 
         val positionScore = if (posThreshold > 0f) (1f - (distance / posThreshold)).coerceIn(0f, 1f) else 1f
         val sizeScore = (1f - ((sizeRatio - 1f) / (effectiveSizeThreshold - 1f).coerceAtLeast(0.01f))).coerceIn(0f, 1f)
-        val labelScore = if (lockedLabel != null && candidate.label == lockedLabel) 1f else 0f
+        // Label match: full bonus for match, penalty for mismatch (prevents
+        // wrong-category objects from scoring high on color/position alone)
+        val labelScore = when {
+            lockedLabel == null -> 0.5f  // unknown label, neutral
+            candidate.label == lockedLabel -> 1f  // exact match
+            else -> -0.5f  // wrong label penalty
+        }
 
         // Color histogram similarity — cheap but very effective for same-category discrimination
         val hasColor = lockedColorHistogram != null && candidate.colorHistogram != null
@@ -292,9 +310,9 @@ class ReacquisitionEngine(
             // Attributes are highly discriminative for persons (gender, clothing, accessories).
             val basePositionWeight = 0.15f
             val baseSizeWeight = 0.10f
-            val baseLabelWeight = if (hasAttrs) 0.05f else 0.10f  // attrs subsume label for persons
+            val baseLabelWeight = if (hasAttrs) 0.10f else 0.20f  // 600 OIV7 classes are reliable
             val baseAttrWeight = if (hasAttrs) 0.15f else 0f
-            val baseAppearanceWeight = if (hasAttrs) 0.30f else 0.40f
+            val baseAppearanceWeight = if (hasAttrs) 0.25f else 0.30f
             val baseColorWeight = if (hasColor) (if (hasAttrs) 0.15f else 0.25f) else 0f
             // Redistribute unused weights to appearance
             val unusedBase = 1f - basePositionWeight - baseSizeWeight - baseLabelWeight -
@@ -308,7 +326,7 @@ class ReacquisitionEngine(
             val attrRedistShare = if (hasAttrs) 0.15f else 0f
             val colorRedistShare = if (hasColor) 0.20f else 0f
             val sizeRedistShare = 0.10f
-            val labelRedistShare = 0.05f
+            val labelRedistShare = 0.15f
             val appearRedistShare = 1f - sizeRedistShare - labelRedistShare - attrRedistShare - colorRedistShare
             val effectiveSizeWeight = baseSizeWeight + redistributed * sizeRedistShare
             val effectiveLabelWeight = baseLabelWeight + redistributed * labelRedistShare
@@ -324,9 +342,9 @@ class ReacquisitionEngine(
                    (colorScore * effectiveColorWeight)
         } else {
             // Fallback: no embedding available, use original weights
-            val basePositionWeight = 0.45f
-            val baseSizeWeight = 0.25f
-            val baseLabelWeight = 0.30f
+            val basePositionWeight = 0.40f
+            val baseSizeWeight = 0.20f
+            val baseLabelWeight = 0.40f
 
             val effectivePositionWeight = basePositionWeight * positionConfidence
             val redistributed = basePositionWeight * (1f - positionConfidence)

--- a/app/src/main/java/com/haptictrack/tracking/Yolov8Detector.kt
+++ b/app/src/main/java/com/haptictrack/tracking/Yolov8Detector.kt
@@ -1,0 +1,244 @@
+package com.haptictrack.tracking
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.RectF
+import android.util.Log
+import org.tensorflow.lite.Interpreter
+import java.io.FileInputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
+
+/**
+ * YOLOv8n-oiv7 label enricher: 601 Open Images classes via TFLite.
+ *
+ * NOT used as the primary detector (EfficientDet-Lite2 handles that).
+ * Instead, runs on-demand to upgrade coarse COCO labels to finer OIV7 labels:
+ * - At lock time: enriches the locked object's label
+ * - During re-acquisition: enriches candidate labels for better discrimination
+ *
+ * Input: [1, 640, 640, 3] float32 (NHWC, 0-1 normalized)
+ * Output: [1, 605, 8400] float32 (4 box coords + 601 class scores × 8400 anchors)
+ */
+class Yolov8Detector(context: Context) {
+
+    companion object {
+        private const val TAG = "Yolov8Det"
+        private const val MODEL_ASSET = "yolov8n_oiv7.tflite"
+        private const val LABELS_ASSET = "oiv7_labels.txt"
+        private const val INPUT_SIZE = 640
+        private const val NUM_CHANNELS = 605  // 4 box + 601 classes
+        private const val NUM_ANCHORS = 8400
+        private const val NUM_CLASSES = 601
+        private const val CONFIDENCE_THRESHOLD = 0.25f
+        private const val NMS_IOU_THRESHOLD = 0.45f
+        private const val MAX_RESULTS = 15
+
+        /** Minimum IoU to consider a YOLOv8 detection as matching an EfficientDet box. */
+        private const val ENRICH_IOU_THRESHOLD = 0.3f
+
+        /** Body-part labels filtered from enrichment results. */
+        private val BODY_PART_LABELS = setOf(
+            "Human arm", "Human beard", "Human ear", "Human eye",
+            "Human foot", "Human hair", "Human hand",
+            "Human head", "Human leg", "Human mouth", "Human nose",
+            "Clothing"
+        )
+
+        /** OIV7 labels that are valid enrichments for COCO "person". */
+        private val PERSON_ENRICHMENTS = setOf(
+            "Person", "Man", "Woman", "Boy", "Girl",
+            "Human face", "Glasses"
+        )
+    }
+
+    private val interpreter: Interpreter
+    private val labels: List<String>
+
+    // Pre-allocated output buffer
+    private val outputArray = Array(1) { Array(NUM_CHANNELS) { FloatArray(NUM_ANCHORS) } }
+
+    init {
+        val model = loadModelFile(context, MODEL_ASSET)
+        interpreter = Interpreter(model, Interpreter.Options().apply { setNumThreads(4) })
+
+        labels = context.assets.open(LABELS_ASSET).bufferedReader().readLines()
+        Log.i(TAG, "Loaded YOLOv8n-oiv7: ${labels.size} classes, input ${INPUT_SIZE}x${INPUT_SIZE}")
+    }
+
+    /**
+     * Enrich a single detection's label by running YOLOv8 on the full frame
+     * and finding the best-matching OIV7 detection by IoU.
+     *
+     * Returns the finer OIV7 label (lowercased), or the original label if no match.
+     */
+    fun enrichLabel(bitmap: Bitmap, box: RectF, coarseLabel: String?): String? {
+        val detections = detect(bitmap)
+        val candidates = detections
+            .filter { it.label !in BODY_PART_LABELS }
+            .filter { iou(it.box, box) > ENRICH_IOU_THRESHOLD }
+            .sortedByDescending { iou(it.box, box) }
+
+        // For "person" detections, only accept person-compatible OIV7 labels
+        // (prevents "person" being overridden by "chair" when sitting)
+        val isPerson = coarseLabel == "person"
+        val best = if (isPerson) {
+            candidates.firstOrNull { it.label in PERSON_ENRICHMENTS }
+        } else {
+            candidates.firstOrNull()
+        }
+
+        if (best != null) {
+            val enriched = best.label.lowercase()
+            Log.d(TAG, "Enriched '$coarseLabel' → '$enriched' (conf=${best.confidence}, iou=${"%.2f".format(iou(best.box, box))})")
+            return enriched
+        }
+        Log.d(TAG, "No enrichment for '$coarseLabel' (${detections.size} OIV7 detections, ${candidates.size} IoU-matched)")
+        return coarseLabel
+    }
+
+    /**
+     * Enrich labels for multiple detections in one pass.
+     * Runs YOLOv8 once, then matches each input box to the best OIV7 detection.
+     */
+    fun enrichLabels(bitmap: Bitmap, objects: List<TrackedObject>): Map<Int, String> {
+        val detections = detect(bitmap)
+        val enriched = mutableMapOf<Int, String>()
+
+        for (obj in objects) {
+            val candidates = detections
+                .filter { it.label !in BODY_PART_LABELS }
+                .filter { iou(it.box, obj.boundingBox) > ENRICH_IOU_THRESHOLD }
+                .sortedByDescending { iou(it.box, obj.boundingBox) }
+
+            val isPerson = obj.label == "person"
+            val best = if (isPerson) {
+                candidates.firstOrNull { it.label in PERSON_ENRICHMENTS }
+            } else {
+                candidates.firstOrNull()
+            }
+
+            if (best != null) {
+                enriched[obj.id] = best.label.lowercase()
+            }
+        }
+
+        if (enriched.isNotEmpty()) {
+            Log.d(TAG, "Enriched ${enriched.size}/${objects.size} labels: $enriched")
+        }
+        return enriched
+    }
+
+    fun close() {
+        interpreter.close()
+    }
+
+    data class Detection(
+        val box: RectF,
+        val label: String,
+        val confidence: Float
+    )
+
+    private fun detect(bitmap: Bitmap): List<Detection> {
+        val resized = Bitmap.createScaledBitmap(bitmap, INPUT_SIZE, INPUT_SIZE, true)
+        val inputBuffer = bitmapToByteBuffer(resized)
+        if (resized !== bitmap) resized.recycle()
+
+        interpreter.run(inputBuffer, outputArray)
+
+        val raw = mutableListOf<Detection>()
+        val output = outputArray[0]
+
+        for (anchor in 0 until NUM_ANCHORS) {
+            var bestClass = 0
+            var bestScore = 0f
+            for (cls in 0 until NUM_CLASSES) {
+                val score = output[4 + cls][anchor]
+                if (score > bestScore) {
+                    bestScore = score
+                    bestClass = cls
+                }
+            }
+
+            if (bestScore < CONFIDENCE_THRESHOLD) continue
+
+            val cx = output[0][anchor]
+            val cy = output[1][anchor]
+            val w = output[2][anchor]
+            val h = output[3][anchor]
+
+            val left = (cx - w / 2f).coerceIn(0f, 1f)
+            val top = (cy - h / 2f).coerceIn(0f, 1f)
+            val right = (cx + w / 2f).coerceIn(0f, 1f)
+            val bottom = (cy + h / 2f).coerceIn(0f, 1f)
+
+            if (right - left < 0.01f || bottom - top < 0.01f) continue
+
+            raw.add(Detection(
+                box = RectF(left, top, right, bottom),
+                label = labels.getOrElse(bestClass) { "unknown" },
+                confidence = bestScore
+            ))
+        }
+
+        return nms(raw).take(MAX_RESULTS)
+    }
+
+    private fun nms(detections: List<Detection>): List<Detection> {
+        val sorted = detections.sortedByDescending { it.confidence }
+        val kept = mutableListOf<Detection>()
+
+        val suppressed = BooleanArray(sorted.size)
+        for (i in sorted.indices) {
+            if (suppressed[i]) continue
+            kept.add(sorted[i])
+            for (j in i + 1 until sorted.size) {
+                if (suppressed[j]) continue
+                if (sorted[i].label == sorted[j].label &&
+                    iou(sorted[i].box, sorted[j].box) > NMS_IOU_THRESHOLD) {
+                    suppressed[j] = true
+                }
+            }
+        }
+        return kept
+    }
+
+    private fun iou(a: RectF, b: RectF): Float {
+        val interLeft = maxOf(a.left, b.left)
+        val interTop = maxOf(a.top, b.top)
+        val interRight = minOf(a.right, b.right)
+        val interBottom = minOf(a.bottom, b.bottom)
+
+        val interArea = maxOf(0f, interRight - interLeft) * maxOf(0f, interBottom - interTop)
+        val aArea = a.width() * a.height()
+        val bArea = b.width() * b.height()
+        val union = aArea + bArea - interArea
+
+        return if (union > 0f) interArea / union else 0f
+    }
+
+    private fun bitmapToByteBuffer(bitmap: Bitmap): ByteBuffer {
+        val buffer = ByteBuffer.allocateDirect(4 * INPUT_SIZE * INPUT_SIZE * 3)
+        buffer.order(ByteOrder.nativeOrder())
+
+        val pixels = IntArray(INPUT_SIZE * INPUT_SIZE)
+        bitmap.getPixels(pixels, 0, INPUT_SIZE, 0, 0, INPUT_SIZE, INPUT_SIZE)
+
+        for (pixel in pixels) {
+            buffer.putFloat(android.graphics.Color.red(pixel) / 255f)
+            buffer.putFloat(android.graphics.Color.green(pixel) / 255f)
+            buffer.putFloat(android.graphics.Color.blue(pixel) / 255f)
+        }
+        buffer.rewind()
+        return buffer
+    }
+
+    private fun loadModelFile(context: Context, assetName: String): MappedByteBuffer {
+        val fd = context.assets.openFd(assetName)
+        val input = FileInputStream(fd.fileDescriptor)
+        val channel = input.channel
+        return channel.map(FileChannel.MapMode.READ_ONLY, fd.startOffset, fd.declaredLength)
+    }
+}


### PR DESCRIPTION
## Summary
- EfficientDet-Lite2 (COCO 80) remains the primary detector — runs every frame, reliable person detection (0.80-0.88)
- YOLOv8n-oiv7 (Open Images 601 classes, 6.8MB) runs on-demand as label enricher: at lock time and every 10th search frame during re-acquisition
- Label enrichment is semantically guarded — COCO "person" can only become Man/Woman/Boy/Girl/Human face, never furniture
- Re-acquisition hardened: wrong-label penalty (-0.5), increased label weight (10-20%), max 3 hops before giving up

## Context
- Tried YOLOv8n-oiv7 as sole detector — person detection regressed badly (0.25-0.40 vs EfficientDet's 0.80-0.88 in indoor scenes)
- OIV7 splits "person" across sub-classes (Boy, Girl, Woman, Man, Clothing, Human face) so no single class gets high confidence
- Two-stage approach gets best of both: reliable EfficientDet boxes + rich OIV7 labels
- Closes #28

## Known issues
- Re-acquisition scoring is complex and non-deterministic — needs reproducible test scenarios from real captures (separate issue)
- Chair-hopping reduced but not eliminated in rooms with many similar objects

## Test plan
- [x] 148 unit tests pass
- [x] Device tested: person detection reliable, label enrichment works (person→boy, dining table→table)
- [x] Chair-hopping scenario improved with hop limit + label penalty
- [ ] Outdoor testing with multiple people at distance

🤖 Generated with [Claude Code](https://claude.com/claude-code)