### PR TITLE
Manual camera controls: pinch zoom, 4K recording, stealth mode (#14)

### DIFF
--- a/app/src/main/java/com/haptictrack/MainActivity.kt
+++ b/app/src/main/java/com/haptictrack/MainActivity.kt
@@ -1,20 +1,34 @@
 package com.haptictrack
 
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import com.haptictrack.ui.CameraScreen
+import com.haptictrack.ui.CameraViewModel
 import com.haptictrack.ui.theme.HapticTrackTheme
 
 class MainActivity : ComponentActivity() {
+
+    private val viewModel: CameraViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             HapticTrackTheme {
-                CameraScreen()
+                CameraScreen(viewModel)
             }
         }
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+            viewModel.onVolumeDown()
+            return true
+        }
+        return super.onKeyDown(keyCode, event)
     }
 }

--- a/app/src/main/java/com/haptictrack/camera/CameraManager.kt
+++ b/app/src/main/java/com/haptictrack/camera/CameraManager.kt
@@ -48,6 +48,13 @@ class CameraManager(private val context: Context) {
     var isFrontCamera: Boolean = false
         private set
 
+    /** When true, ImageAnalysis is unbound to free a stream for higher video resolution. */
+    private var recordingMode: Boolean = false
+
+    /** Whether ImageAnalysis is currently active (false during recording). */
+    var analysisActive: Boolean = true
+        private set
+
     val preview = Preview.Builder().build()
 
     val imageAnalysis: ImageAnalysis = ImageAnalysis.Builder()
@@ -61,17 +68,22 @@ class CameraManager(private val context: Context) {
         )
         .build()
 
-    private val recorder = Recorder.Builder()
-        .setQualitySelector(
-            QualitySelector.fromOrderedList(
-                listOf(Quality.UHD, Quality.FHD, Quality.HD),
-                FallbackStrategy.higherQualityOrLowerThan(Quality.FHD)
-            )
-        )
-        .setExecutor(Executors.newSingleThreadExecutor())
-        .build()
+    private val videoExecutor = Executors.newSingleThreadExecutor()
+    var videoCapture = createVideoCapture()
+        private set
 
-    val videoCapture = VideoCapture.withOutput(recorder)
+    private fun createVideoCapture(): VideoCapture<Recorder> {
+        val recorder = Recorder.Builder()
+            .setQualitySelector(
+                QualitySelector.fromOrderedList(
+                    listOf(Quality.UHD, Quality.FHD, Quality.HD),
+                    FallbackStrategy.higherQualityOrLowerThan(Quality.FHD)
+                )
+            )
+            .setExecutor(videoExecutor)
+            .build()
+        return VideoCapture.withOutput(recorder)
+    }
 
     init {
         opticalZoomMax = detectOpticalZoomMax()
@@ -100,29 +112,57 @@ class CameraManager(private val context: Context) {
         Log.i(TAG, "Switched to ${if (isFrontCamera) "front" else "back"} camera")
     }
 
+    /**
+     * Switch to recording mode (2 streams: preview + video → higher video resolution).
+     * Analysis frames must be obtained via PreviewView.getBitmap().
+     */
+    fun enterRecordingMode() {
+        if (recordingMode) return
+        recordingMode = true
+        val owner = lifecycleOwnerRef ?: return
+        val view = previewViewRef ?: return
+        bindUseCases(owner, view)
+    }
+
+    /**
+     * Switch back to tracking mode (3 streams: preview + analysis + video).
+     * ImageAnalysis provides full-quality frames for detection.
+     */
+    fun exitRecordingMode() {
+        if (!recordingMode) return
+        recordingMode = false
+        val owner = lifecycleOwnerRef ?: return
+        val view = previewViewRef ?: return
+        bindUseCases(owner, view)
+    }
+
     private fun bindUseCases(lifecycleOwner: LifecycleOwner, previewView: PreviewView) {
         val provider = cameraProvider ?: return
         provider.unbindAll()
+
+        // Recreate VideoCapture to avoid resolution mismatch when switching modes
+        videoCapture = createVideoCapture()
 
         preview.surfaceProvider = previewView.surfaceProvider
 
         val selector = if (isFrontCamera) CameraSelector.DEFAULT_FRONT_CAMERA
                        else CameraSelector.DEFAULT_BACK_CAMERA
 
-        val camera = provider.bindToLifecycle(
-            lifecycleOwner,
-            selector,
-            preview,
-            imageAnalysis,
-            videoCapture
-        )
+        val camera = if (recordingMode) {
+            // 2 streams: preview + video → 4K video, analysis via getBitmap()
+            provider.bindToLifecycle(lifecycleOwner, selector, preview, videoCapture)
+        } else {
+            // 3 streams: preview + analysis + video → full-quality analysis
+            provider.bindToLifecycle(lifecycleOwner, selector, preview, imageAnalysis, videoCapture)
+        }
+        analysisActive = !recordingMode
 
         cameraControl = camera.cameraControl
         cameraInfo = camera.cameraInfo
 
         val previewRes = preview.resolutionInfo?.resolution
-        val analysisRes = imageAnalysis.resolutionInfo?.resolution
-        Log.i(TAG, "Bound use cases — preview: $previewRes, analysis: $analysisRes")
+        val analysisRes = if (!recordingMode) imageAnalysis.resolutionInfo?.resolution else null
+        Log.i(TAG, "Bound use cases — preview: $previewRes, analysis: $analysisRes, mode: ${if (recordingMode) "recording (2-stream)" else "tracking (3-stream)"}")
     }
 
     fun setZoomRatio(ratio: Float) {

--- a/app/src/main/java/com/haptictrack/camera/CameraManager.kt
+++ b/app/src/main/java/com/haptictrack/camera/CameraManager.kt
@@ -10,6 +10,9 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
+import androidx.camera.video.FallbackStrategy
 import androidx.camera.video.Quality
 import androidx.camera.video.QualitySelector
 import androidx.camera.video.Recorder
@@ -18,6 +21,7 @@ import androidx.camera.view.PreviewView
 import androidx.lifecycle.LifecycleOwner
 import android.os.Handler
 import android.os.Looper
+import android.util.Size
 import java.util.concurrent.Executors
 
 class CameraManager(private val context: Context) {
@@ -48,10 +52,22 @@ class CameraManager(private val context: Context) {
 
     val imageAnalysis: ImageAnalysis = ImageAnalysis.Builder()
         .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+        .setResolutionSelector(
+            ResolutionSelector.Builder()
+                .setResolutionStrategy(
+                    ResolutionStrategy(Size(640, 480), ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER_THEN_HIGHER)
+                )
+                .build()
+        )
         .build()
 
     private val recorder = Recorder.Builder()
-        .setQualitySelector(QualitySelector.from(Quality.HIGHEST))
+        .setQualitySelector(
+            QualitySelector.fromOrderedList(
+                listOf(Quality.UHD, Quality.FHD, Quality.HD),
+                FallbackStrategy.higherQualityOrLowerThan(Quality.FHD)
+            )
+        )
         .setExecutor(Executors.newSingleThreadExecutor())
         .build()
 
@@ -103,6 +119,10 @@ class CameraManager(private val context: Context) {
 
         cameraControl = camera.cameraControl
         cameraInfo = camera.cameraInfo
+
+        val previewRes = preview.resolutionInfo?.resolution
+        val analysisRes = imageAnalysis.resolutionInfo?.resolution
+        Log.i(TAG, "Bound use cases — preview: $previewRes, analysis: $analysisRes")
     }
 
     fun setZoomRatio(ratio: Float) {

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -153,13 +153,7 @@ class ObjectTracker(
      * no rotation is applied, and detector coordinates are used as-is (deviceRot=0).
      */
     fun processBitmap(bitmap: Bitmap) {
-        val savedProvider = deviceRotationProvider
-        deviceRotationProvider = { 0 } // getBitmap is already display-oriented
-        try {
-            processBitmapInternal(bitmap, needsRotation = false, imageProxy = null)
-        } finally {
-            deviceRotationProvider = savedProvider
-        }
+        processBitmapInternal(bitmap, deviceRotation = 0, imageProxy = null)
     }
 
     private fun processImage(imageProxy: ImageProxy) {
@@ -168,10 +162,10 @@ class ObjectTracker(
             imageProxy.close()
             return
         }
-        processBitmapInternal(bitmap, needsRotation = true, imageProxy = imageProxy)
+        processBitmapInternal(bitmap, deviceRotation = deviceRotationProvider?.invoke() ?: 0, imageProxy = imageProxy)
     }
 
-    private fun processBitmapInternal(bitmap: Bitmap, needsRotation: Boolean, imageProxy: ImageProxy?) {
+    private fun processBitmapInternal(bitmap: Bitmap, deviceRotation: Int, imageProxy: ImageProxy?) {
         val frameWidth = bitmap.width
         val frameHeight = bitmap.height
 
@@ -183,12 +177,12 @@ class ObjectTracker(
                 val vtResult = visualTracker.update(bitmap)
                 if (vtResult != null) {
                     // Run detector anyway to validate and for display
-                    val detections = runDetector(bitmap, frameWidth, frameHeight)
+                    val detections = runDetector(bitmap, frameWidth, frameHeight, deviceRotation)
                     val tracked = frameTracker.assignIds(detections)
 
                     // VT returns coords in rotated-image space; unmap to screen space
                     // to match detector boxes (which are already unmapped).
-                    val deviceRot = deviceRotationProvider?.invoke() ?: 0
+                    val deviceRot = deviceRotation
                     val rawBox = vtResult.boundingBox
                     val vtBox = unmapRotation(rawBox.left, rawBox.top, rawBox.right, rawBox.bottom, deviceRot)
                     val confirmed = tracked.any { det ->
@@ -268,7 +262,7 @@ class ObjectTracker(
             }
 
             // --- Detector path: detection + re-acquisition ---
-            val detections = runDetector(bitmap, frameWidth, frameHeight)
+            val detections = runDetector(bitmap, frameWidth, frameHeight, deviceRotation)
             val tracked = frameTracker.assignIds(detections)
 
             // Compute embeddings when searching OR when the direct ID match might
@@ -363,7 +357,7 @@ class ObjectTracker(
 
             // Update contour on re-acquire or periodically (gated — disabled until UI uses it)
             if (contourEnabled) {
-                val deviceRot = deviceRotationProvider?.invoke() ?: 0
+                val deviceRot = deviceRotation
                 if (lockedObject != null && reacquisition.framesLost == 0) {
                     contourFrameCount++
                     if (contourFrameCount % CONTOUR_UPDATE_INTERVAL_DET == 0 || (wasSearching && reacquisition.framesLost == 0)) {
@@ -387,10 +381,9 @@ class ObjectTracker(
         }
     }
 
-    private fun runDetector(bitmap: Bitmap, frameWidth: Int, frameHeight: Int): List<TrackedObject> {
+    private fun runDetector(bitmap: Bitmap, frameWidth: Int, frameHeight: Int, deviceRot: Int): List<TrackedObject> {
         val mpImage = BitmapImageBuilder(bitmap).build()
         val result: ObjectDetectorResult = detector.detect(mpImage)
-        val deviceRot = deviceRotationProvider?.invoke() ?: 0
 
         return result.detections().map { detection ->
             val box = detection.boundingBox()

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -118,6 +118,18 @@ class ObjectTracker(
         }
     }
 
+    /**
+     * Prepare for a camera rebind. Stops visual tracker and forces
+     * re-acquisition engine into search mode so it recovers on the
+     * first frame after the camera restarts.
+     */
+    fun prepareForRebind() {
+        if (!reacquisition.isLocked) return
+        visualTracker.stop()
+        vtUnconfirmedFrames = 0
+        reacquisition.prepareForRebind()
+    }
+
     fun clearLock() {
         scenarioRecorder.recordEvent("CLEAR")
         scenarioRecorder.stop()
@@ -136,12 +148,18 @@ class ObjectTracker(
     }
 
     /**
-     * Process a pre-rotated bitmap from PreviewView.getBitmap().
-     * Unlike the ImageProxy path, the bitmap is already in screen orientation
-     * and does NOT need rotation correction.
+     * Process a display-oriented bitmap from PreviewView.getBitmap().
+     * Unlike the ImageProxy path, the bitmap is already in screen orientation —
+     * no rotation is applied, and detector coordinates are used as-is (deviceRot=0).
      */
     fun processBitmap(bitmap: Bitmap) {
-        processBitmapInternal(bitmap, needsRotation = false, imageProxy = null)
+        val savedProvider = deviceRotationProvider
+        deviceRotationProvider = { 0 } // getBitmap is already display-oriented
+        try {
+            processBitmapInternal(bitmap, needsRotation = false, imageProxy = null)
+        } finally {
+            deviceRotationProvider = savedProvider
+        }
     }
 
     private fun processImage(imageProxy: ImageProxy) {

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -135,13 +135,25 @@ class ObjectTracker(
         processImage(imageProxy)
     }
 
+    /**
+     * Process a pre-rotated bitmap from PreviewView.getBitmap().
+     * Unlike the ImageProxy path, the bitmap is already in screen orientation
+     * and does NOT need rotation correction.
+     */
+    fun processBitmap(bitmap: Bitmap) {
+        processBitmapInternal(bitmap, needsRotation = false, imageProxy = null)
+    }
+
     private fun processImage(imageProxy: ImageProxy) {
         val bitmap = imageProxyToBitmap(imageProxy)
         if (bitmap == null) {
             imageProxy.close()
             return
         }
+        processBitmapInternal(bitmap, needsRotation = true, imageProxy = imageProxy)
+    }
 
+    private fun processBitmapInternal(bitmap: Bitmap, needsRotation: Boolean, imageProxy: ImageProxy?) {
         val frameWidth = bitmap.width
         val frameHeight = bitmap.height
 
@@ -352,7 +364,7 @@ class ObjectTracker(
 
             onDetectionResult?.invoke(displayObjects, lockedObject, frameWidth, frameHeight, cachedContour)
         } finally {
-            imageProxy.close()
+            imageProxy?.close()
             bitmap.recycle()
         }
     }

--- a/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
@@ -203,6 +203,17 @@ class ReacquisitionEngine(
         framesLost = 0
     }
 
+    /**
+     * Prepare for a camera rebind that will interrupt the frame stream.
+     * Forces into search mode so the first frame after rebind triggers re-acquisition
+     * using the full embedding gallery. Call before unbinding camera use cases.
+     */
+    fun prepareForRebind() {
+        if (!isLocked) return
+        framesLost = 1
+        android.util.Log.i("Reacq", "REBIND_PREPARE — forced search mode, gallery=${embeddingGallery.size}")
+    }
+
     internal fun positionConfidence(): Float {
         if (framesLost <= 0) return 1f
         return (1f - framesLost.toFloat() / positionDecayFrames).coerceIn(0f, 1f)

--- a/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
+++ b/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
@@ -10,6 +10,11 @@ enum class TrackingStatus {
     LOST
 }
 
+enum class CaptureMode {
+    VIDEO,
+    PHOTO
+}
+
 /**
  * Person attributes from Crossroad-0230 classifier.
  * All boolean fields use threshold > 0.5 on model output probabilities.
@@ -148,5 +153,8 @@ data class TrackingUiState(
     /** Source image height (post-rotation, i.e. portrait height). */
     val sourceImageHeight: Int = 0,
     /** Contour points of the locked object in normalized [0,1] coordinates. */
-    val lockedContour: List<PointF> = emptyList()
+    val lockedContour: List<PointF> = emptyList(),
+    val captureMode: CaptureMode = CaptureMode.VIDEO,
+    /** True when zoom indicator should be visible (during/after pinch). */
+    val showZoomIndicator: Boolean = false
 )

--- a/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
+++ b/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
@@ -156,5 +156,7 @@ data class TrackingUiState(
     val lockedContour: List<PointF> = emptyList(),
     val captureMode: CaptureMode = CaptureMode.VIDEO,
     /** True when zoom indicator should be visible (during/after pinch). */
-    val showZoomIndicator: Boolean = false
+    val showZoomIndicator: Boolean = false,
+    /** Stealth mode: preview hidden, screen stays black. */
+    val stealthMode: Boolean = false
 )

--- a/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
@@ -237,7 +237,7 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
         var isScaling by remember { mutableStateOf(false) }
 
         Box(modifier = Modifier.fillMaxSize()) {
-            // Camera preview
+            // Camera preview (always full size — getBitmap needs rendered pixels)
             AndroidView(
                 factory = { previewView },
                 modifier = Modifier
@@ -274,6 +274,11 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                         }
                     }
             )
+
+            // Stealth mode: black overlay hides preview but keeps it rendering for getBitmap
+            if (uiState.stealthMode) {
+                Box(modifier = Modifier.fillMaxSize().background(Color.Black))
+            }
 
             // Bounding box / contour overlay
             TrackingOverlay(
@@ -348,7 +353,7 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
             }
 
             // Switch camera button
-            if (uiState.status == TrackingStatus.IDLE) {
+            if (uiState.status == TrackingStatus.IDLE && !uiState.stealthMode) {
                 Button(
                     onClick = { viewModel.switchCamera() },
                     modifier = Modifier
@@ -358,6 +363,23 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                 ) {
                     Text("\u21BB", color = Color.White, fontSize = 18.sp)
                 }
+            }
+
+            // Stealth mode toggle
+            Button(
+                onClick = { viewModel.toggleStealthMode() },
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(top = if (uiState.stealthMode || uiState.status != TrackingStatus.IDLE) 64.dp else 112.dp, start = 16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (uiState.stealthMode) HapticRed.copy(alpha = 0.7f) else Color.Black.copy(alpha = 0.5f)
+                )
+            ) {
+                Text(
+                    if (uiState.stealthMode) "EXIT" else "STEALTH",
+                    color = Color.White,
+                    fontSize = 12.sp
+                )
             }
         }
     } else {

--- a/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
@@ -2,6 +2,7 @@ package com.haptictrack.ui
 
 import android.graphics.RectF
 import android.view.MotionEvent
+import android.view.ScaleGestureDetector
 import androidx.camera.view.PreviewView
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -10,8 +11,11 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -44,13 +48,17 @@ import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import kotlin.math.abs
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.haptictrack.tracking.CaptureMode
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -201,6 +209,33 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
             previousLockedId = currentId
         }
 
+        // --- Zoom indicator fade-out ---
+        val zoomIndicatorOpacity = remember { Animatable(0f) }
+        LaunchedEffect(uiState.showZoomIndicator) {
+            if (uiState.showZoomIndicator) {
+                zoomIndicatorOpacity.snapTo(1f)
+            } else {
+                // Fade out over 500ms
+                zoomIndicatorOpacity.animateTo(0f, tween(500, easing = FastOutSlowInEasing))
+            }
+        }
+
+        // Pinch-to-zoom detector — lives outside recomposition
+        val scaleDetector = remember {
+            ScaleGestureDetector(context, object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+                override fun onScale(detector: ScaleGestureDetector): Boolean {
+                    viewModel.onPinchZoom(detector.scaleFactor)
+                    return true
+                }
+                override fun onScaleEnd(detector: ScaleGestureDetector) {
+                    // Start the fade-out after a short hold
+                    viewModel.hideZoomIndicator()
+                }
+            })
+        }
+        // Track whether a scale gesture is in progress to suppress tap-on-release
+        var isScaling by remember { mutableStateOf(false) }
+
         Box(modifier = Modifier.fillMaxSize()) {
             // Camera preview
             AndroidView(
@@ -208,18 +243,35 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                 modifier = Modifier
                     .fillMaxSize()
                     .pointerInteropFilter { event ->
-                        if (event.action == MotionEvent.ACTION_DOWN) {
-                            val transform = computeFillCenterTransform(
-                                previewView.width.toFloat(),
-                                previewView.height.toFloat(),
-                                uiState.sourceImageWidth,
-                                uiState.sourceImageHeight
-                            )
-                            val normalizedX = transform.toNormalizedX(event.x)
-                            val normalizedY = transform.toNormalizedY(event.y)
-                            viewModel.onTapToLock(normalizedX, normalizedY)
-                            true
-                        } else false
+                        scaleDetector.onTouchEvent(event)
+
+                        if (scaleDetector.isInProgress) {
+                            isScaling = true
+                            return@pointerInteropFilter true
+                        }
+
+                        when (event.action) {
+                            MotionEvent.ACTION_DOWN -> {
+                                isScaling = false
+                                true
+                            }
+                            MotionEvent.ACTION_UP -> {
+                                if (!isScaling && event.pointerCount <= 1) {
+                                    val transform = computeFillCenterTransform(
+                                        previewView.width.toFloat(),
+                                        previewView.height.toFloat(),
+                                        uiState.sourceImageWidth,
+                                        uiState.sourceImageHeight
+                                    )
+                                    val normalizedX = transform.toNormalizedX(event.x)
+                                    val normalizedY = transform.toNormalizedY(event.y)
+                                    viewModel.onTapToLock(normalizedX, normalizedY)
+                                }
+                                isScaling = false
+                                true
+                            }
+                            else -> true
+                        }
                     }
             )
 
@@ -243,9 +295,39 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                     .padding(top = 64.dp)
             )
 
+            // Zoom level indicator — always visible when tracking, fades after pinch otherwise
+            val showZoomAlways = uiState.status == TrackingStatus.LOCKED || uiState.status == TrackingStatus.LOST
+            val zoomAlpha = if (showZoomAlways) 1f else zoomIndicatorOpacity.value
+            if (zoomAlpha > 0.01f) {
+                Text(
+                    text = "×${"%.1f".format(uiState.currentZoomRatio)}",
+                    color = Color.White.copy(alpha = zoomAlpha),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(top = 100.dp)
+                        .background(
+                            Color.Black.copy(alpha = 0.5f * zoomAlpha),
+                            RoundedCornerShape(16.dp)
+                        )
+                        .padding(horizontal = 12.dp, vertical = 4.dp)
+                )
+            }
+
+            // Capture mode selector (swipeable)
+            CaptureModePill(
+                captureMode = uiState.captureMode,
+                onToggle = { viewModel.toggleCaptureMode() },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 132.dp)
+            )
+
             // Record button
             RecordButton(
                 isRecording = uiState.isRecording,
+                captureMode = uiState.captureMode,
                 onClick = { viewModel.toggleRecording() },
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -548,19 +630,82 @@ private fun StatusBadge(state: TrackingUiState, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun RecordButton(isRecording: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+private fun RecordButton(
+    isRecording: Boolean,
+    captureMode: CaptureMode = CaptureMode.VIDEO,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Button(
         onClick = onClick,
         modifier = modifier.size(72.dp),
         shape = CircleShape,
         colors = ButtonDefaults.buttonColors(
-            containerColor = if (isRecording) HapticRed else Color.White
+            containerColor = when {
+                isRecording -> HapticRed
+                captureMode == CaptureMode.PHOTO -> Color.White
+                else -> Color.White
+            }
         )
     ) {
         if (isRecording) {
             Canvas(modifier = Modifier.size(24.dp)) {
                 drawRect(color = Color.White)
             }
+        } else if (captureMode == CaptureMode.PHOTO) {
+            // Inner circle for photo mode (camera shutter style)
+            Canvas(modifier = Modifier.size(28.dp)) {
+                drawCircle(color = Color.White)
+                drawCircle(color = Color.Black.copy(alpha = 0.15f), radius = size.minDimension / 2f * 0.85f)
+            }
         }
     }
+}
+
+@Composable
+private fun CaptureModePill(
+    captureMode: CaptureMode,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var totalDrag by remember { mutableStateOf(0f) }
+
+    Row(
+        modifier = modifier
+            .background(Color.Black.copy(alpha = 0.4f), RoundedCornerShape(16.dp))
+            .padding(horizontal = 4.dp, vertical = 2.dp)
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onDragEnd = {
+                        if (abs(totalDrag) > 50f) {
+                            onToggle()
+                        }
+                        totalDrag = 0f
+                    },
+                    onHorizontalDrag = { _, dragAmount ->
+                        totalDrag += dragAmount
+                    }
+                )
+            },
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        ModeLabel("VIDEO", selected = captureMode == CaptureMode.VIDEO)
+        ModeLabel("PHOTO", selected = captureMode == CaptureMode.PHOTO)
+    }
+}
+
+@Composable
+private fun ModeLabel(text: String, selected: Boolean) {
+    Text(
+        text = text,
+        color = if (selected) Color.White else Color.White.copy(alpha = 0.5f),
+        fontSize = 12.sp,
+        fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+        modifier = Modifier
+            .background(
+                if (selected) Color.White.copy(alpha = 0.15f) else Color.Transparent,
+                RoundedCornerShape(12.dp)
+            )
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+    )
 }

--- a/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
@@ -663,11 +663,7 @@ private fun RecordButton(
         modifier = modifier.size(72.dp),
         shape = CircleShape,
         colors = ButtonDefaults.buttonColors(
-            containerColor = when {
-                isRecording -> HapticRed
-                captureMode == CaptureMode.PHOTO -> Color.White
-                else -> Color.White
-            }
+            containerColor = if (isRecording) HapticRed else Color.White
         )
     ) {
         if (isRecording) {

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -1,8 +1,6 @@
 package com.haptictrack.ui
 
 import android.app.Application
-import android.graphics.Bitmap
-import android.graphics.Matrix
 import android.graphics.RectF
 import android.util.Log
 import androidx.camera.video.VideoRecordEvent
@@ -52,6 +50,8 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         private const val TAP_PADDING = 0.03f
         /** Target interval between getBitmap() analysis frames (ms). */
         private const val BITMAP_ANALYSIS_INTERVAL_MS = 50L // ~20fps
+        /** Downscale getBitmap to this width for analysis (matches ImageAnalysis res). */
+        private const val ANALYSIS_TARGET_WIDTH = 640
     }
 
     /** Smooths idle detections by keeping objects alive for a few frames after they disappear. */
@@ -234,6 +234,20 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    fun toggleStealthMode() {
+        val entering = !_uiState.value.stealthMode
+        _uiState.update { it.copy(stealthMode = entering) }
+        // Prepare tracker for camera rebind so it recovers quickly
+        objectTracker.prepareForRebind()
+        if (entering) {
+            cameraManager.enterRecordingMode()
+            startBitmapAnalysis()
+        } else {
+            stopBitmapAnalysis()
+            cameraManager.exitRecordingMode()
+        }
+    }
+
     fun switchCamera() {
         clearTracking()
         cameraManager.switchCamera()
@@ -244,29 +258,34 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         zoomController.reset()
         hapticManager.updateTrackingStatus(TrackingStatus.IDLE)
         _uiState.update {
-            TrackingUiState(status = TrackingStatus.IDLE, isRecording = it.isRecording, captureMode = it.captureMode)
+            TrackingUiState(status = TrackingStatus.IDLE, isRecording = it.isRecording, captureMode = it.captureMode, stealthMode = it.stealthMode)
         }
     }
 
     @android.annotation.SuppressLint("MissingPermission")
     fun toggleRecording() {
+        val inStealth = _uiState.value.stealthMode
+
         if (recordingManager.isRecording) {
             recordingManager.stopRecording()
-            stopBitmapAnalysis()
+            if (!inStealth) stopBitmapAnalysis()
             // Don't exit recording mode here — wait for Finalize callback
-            // so the recording file is properly closed before rebinding
         } else {
-            // Switch to 2-stream mode for higher video resolution
-            cameraManager.enterRecordingMode()
-            startBitmapAnalysis()
+            if (!inStealth) {
+                objectTracker.prepareForRebind()
+                cameraManager.enterRecordingMode()
+                startBitmapAnalysis()
+            }
             recordingManager.startRecording(cameraManager.videoCapture) { event ->
                 when (event) {
                     is VideoRecordEvent.Start ->
                         _uiState.update { it.copy(isRecording = true) }
                     is VideoRecordEvent.Finalize -> {
                         _uiState.update { it.copy(isRecording = false) }
-                        // Now safe to rebind with 3 streams
-                        cameraManager.exitRecordingMode()
+                        if (!inStealth) {
+                            objectTracker.prepareForRebind()
+                            cameraManager.exitRecordingMode()
+                        }
                     }
                 }
             }
@@ -286,17 +305,20 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
                 val preview = previewViewRef
                 val bitmap = preview?.bitmap
                 if (bitmap != null) {
-                    // Process off main thread
-                    launch(Dispatchers.Default) {
-                        val deviceRot = orientationListener.deviceRotation
-                        val rotated = if (deviceRot != 0) {
-                            val matrix = Matrix().apply { postRotate(deviceRot.toFloat()) }
-                            val r = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
-                            if (r !== bitmap) bitmap.recycle()
-                            r
+                    kotlinx.coroutines.withContext(Dispatchers.Default) {
+                        // Downscale to ~640px wide to match ImageAnalysis resolution.
+                        // Full screen resolution (1440x3200) is 15x more pixels and
+                        // takes ~500ms per frame vs ~30ms at 640px.
+                        val scale = ANALYSIS_TARGET_WIDTH.toFloat() / bitmap.width
+                        val scaled = if (scale < 0.9f) {
+                            val w = (bitmap.width * scale).toInt()
+                            val h = (bitmap.height * scale).toInt()
+                            android.graphics.Bitmap.createScaledBitmap(bitmap, w, h, true).also {
+                                bitmap.recycle()
+                            }
                         } else bitmap
 
-                        objectTracker.processBitmap(rotated)
+                        objectTracker.processBitmap(scaled)
                     }
                 }
                 delay(BITMAP_ANALYSIS_INTERVAL_MS)

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -10,6 +10,7 @@ import com.haptictrack.camera.CameraManager
 import com.haptictrack.camera.DeviceOrientationListener
 import com.haptictrack.camera.RecordingManager
 import com.haptictrack.haptics.HapticFeedbackManager
+import com.haptictrack.tracking.CaptureMode
 import com.haptictrack.tracking.ObjectTracker
 import com.haptictrack.tracking.TrackedObject
 import com.haptictrack.tracking.TrackingStatus
@@ -148,6 +149,74 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         private const val TAP_PADDING = 0.03f
     }
 
+    /**
+     * Handle pinch-to-zoom gesture. [scaleFactor] is the incremental scale from the gesture
+     * (e.g. 1.05 = 5% zoom in, 0.95 = 5% zoom out).
+     */
+    fun onPinchZoom(scaleFactor: Float) {
+        val currentZoom = zoomController.getCurrentZoom()
+        val newZoom = currentZoom * scaleFactor
+        val appliedZoom = zoomController.setManualZoom(
+            newZoom, cameraManager.getMinZoom(), cameraManager.getMaxZoom()
+        )
+        cameraManager.setZoomRatio(appliedZoom)
+        _uiState.update { it.copy(currentZoomRatio = appliedZoom, showZoomIndicator = true) }
+    }
+
+    /** Called when pinch gesture ends — starts the fade-out timer for the zoom indicator. */
+    fun onPinchEnd() {
+        // The indicator fade-out is handled by LaunchedEffect in CameraScreen
+    }
+
+    /** Hide the zoom indicator (called after fade-out delay). */
+    fun hideZoomIndicator() {
+        _uiState.update { it.copy(showZoomIndicator = false) }
+    }
+
+    /**
+     * Volume-down handler — three-stage cycle:
+     * 1. Idle → lock on center object
+     * 2. Tracking (not recording) → start recording
+     * 3. Recording → stop recording + clear tracking
+     */
+    fun onVolumeDown() {
+        val state = _uiState.value
+
+        if (state.isRecording) {
+            // Stage 3: stop recording and clear
+            toggleRecording()
+            clearTracking()
+            return
+        }
+
+        if (state.status != TrackingStatus.IDLE) {
+            // Stage 2: tracking but not recording — start recording
+            toggleRecording()
+            return
+        }
+
+        // Stage 1: idle — lock on center
+        val objects = state.detectedObjects.filter { it.id >= 0 }
+        if (objects.isEmpty()) return
+
+        val closest = objects.minByOrNull { obj ->
+            val cx = obj.boundingBox.centerX() - 0.5f
+            val cy = obj.boundingBox.centerY() - 0.5f
+            cx * cx + cy * cy
+        } ?: return
+
+        objectTracker.lockOnObject(closest.id, closest.boundingBox, closest.label)
+        _uiState.update { it.copy(status = TrackingStatus.LOCKED, trackedObject = closest) }
+    }
+
+    fun toggleCaptureMode() {
+        _uiState.update { current ->
+            current.copy(
+                captureMode = if (current.captureMode == CaptureMode.VIDEO) CaptureMode.PHOTO else CaptureMode.VIDEO
+            )
+        }
+    }
+
     fun switchCamera() {
         clearTracking()
         cameraManager.switchCamera()
@@ -158,7 +227,7 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         zoomController.reset()
         hapticManager.updateTrackingStatus(TrackingStatus.IDLE)
         _uiState.update {
-            TrackingUiState(status = TrackingStatus.IDLE, isRecording = it.isRecording)
+            TrackingUiState(status = TrackingStatus.IDLE, isRecording = it.isRecording, captureMode = it.captureMode)
         }
     }
 

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -180,11 +180,6 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         _uiState.update { it.copy(currentZoomRatio = appliedZoom, showZoomIndicator = true) }
     }
 
-    /** Called when pinch gesture ends — starts the fade-out timer for the zoom indicator. */
-    fun onPinchEnd() {
-        // The indicator fade-out is handled by LaunchedEffect in CameraScreen
-    }
-
     /** Hide the zoom indicator (called after fade-out delay). */
     fun hideZoomIndicator() {
         _uiState.update { it.copy(showZoomIndicator = false) }
@@ -236,8 +231,11 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun toggleStealthMode() {
         val entering = !_uiState.value.stealthMode
+        if (!entering && _uiState.value.isRecording) {
+            // Stop recording before exiting stealth — rebind would kill VideoCapture
+            recordingManager.stopRecording()
+        }
         _uiState.update { it.copy(stealthMode = entering) }
-        // Prepare tracker for camera rebind so it recovers quickly
         objectTracker.prepareForRebind()
         if (entering) {
             cameraManager.enterRecordingMode()
@@ -264,14 +262,11 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
 
     @android.annotation.SuppressLint("MissingPermission")
     fun toggleRecording() {
-        val inStealth = _uiState.value.stealthMode
-
         if (recordingManager.isRecording) {
             recordingManager.stopRecording()
-            if (!inStealth) stopBitmapAnalysis()
-            // Don't exit recording mode here — wait for Finalize callback
+            if (!_uiState.value.stealthMode) stopBitmapAnalysis()
         } else {
-            if (!inStealth) {
+            if (!_uiState.value.stealthMode) {
                 objectTracker.prepareForRebind()
                 cameraManager.enterRecordingMode()
                 startBitmapAnalysis()
@@ -282,7 +277,8 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
                         _uiState.update { it.copy(isRecording = true) }
                     is VideoRecordEvent.Finalize -> {
                         _uiState.update { it.copy(isRecording = false) }
-                        if (!inStealth) {
+                        // Read stealth state at callback time, not at call time
+                        if (!_uiState.value.stealthMode) {
                             objectTracker.prepareForRebind()
                             cameraManager.exitRecordingMode()
                         }

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -1,11 +1,15 @@
 package com.haptictrack.ui
 
 import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.Matrix
 import android.graphics.RectF
+import android.util.Log
 import androidx.camera.video.VideoRecordEvent
 import androidx.camera.view.PreviewView
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.viewModelScope
 import com.haptictrack.camera.CameraManager
 import com.haptictrack.camera.DeviceOrientationListener
 import com.haptictrack.camera.RecordingManager
@@ -16,10 +20,15 @@ import com.haptictrack.tracking.TrackedObject
 import com.haptictrack.tracking.TrackingStatus
 import com.haptictrack.tracking.TrackingUiState
 import com.haptictrack.zoom.ZoomController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 class CameraViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -32,6 +41,18 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
 
     private val _uiState = MutableStateFlow(TrackingUiState())
     val uiState: StateFlow<TrackingUiState> = _uiState.asStateFlow()
+
+    /** Coroutine job for getBitmap() analysis loop during recording. */
+    private var bitmapAnalysisJob: Job? = null
+    private var previewViewRef: PreviewView? = null
+
+    companion object {
+        private const val TAG = "CameraVM"
+        /** Tap target padding in normalized coordinates (~3% of screen on each side). */
+        private const val TAP_PADDING = 0.03f
+        /** Target interval between getBitmap() analysis frames (ms). */
+        private const val BITMAP_ANALYSIS_INTERVAL_MS = 50L // ~20fps
+    }
 
     /** Smooths idle detections by keeping objects alive for a few frames after they disappear. */
     private val recentDetections = mutableMapOf<Int, Pair<TrackedObject, Int>>() // id → (object, framesRemaining)
@@ -100,6 +121,7 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun startCamera(lifecycleOwner: LifecycleOwner, previewView: PreviewView) {
+        previewViewRef = previewView
         cameraManager.startCamera(lifecycleOwner, previewView)
     }
 
@@ -142,11 +164,6 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         stale.forEach { recentDetections.remove(it) }
 
         return recentDetections.values.map { it.first }
-    }
-
-    companion object {
-        /** Tap target padding in normalized coordinates (~3% of screen on each side). */
-        private const val TAP_PADDING = 0.03f
     }
 
     /**
@@ -235,21 +252,67 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
     fun toggleRecording() {
         if (recordingManager.isRecording) {
             recordingManager.stopRecording()
-            _uiState.update { it.copy(isRecording = false) }
+            stopBitmapAnalysis()
+            // Don't exit recording mode here — wait for Finalize callback
+            // so the recording file is properly closed before rebinding
         } else {
+            // Switch to 2-stream mode for higher video resolution
+            cameraManager.enterRecordingMode()
+            startBitmapAnalysis()
             recordingManager.startRecording(cameraManager.videoCapture) { event ->
                 when (event) {
                     is VideoRecordEvent.Start ->
                         _uiState.update { it.copy(isRecording = true) }
-                    is VideoRecordEvent.Finalize ->
+                    is VideoRecordEvent.Finalize -> {
                         _uiState.update { it.copy(isRecording = false) }
+                        // Now safe to rebind with 3 streams
+                        cameraManager.exitRecordingMode()
+                    }
                 }
             }
         }
     }
 
+    /**
+     * Start a coroutine loop that pulls bitmaps from PreviewView for analysis.
+     * Used during recording when ImageAnalysis is unbound.
+     */
+    private fun startBitmapAnalysis() {
+        bitmapAnalysisJob?.cancel()
+        bitmapAnalysisJob = viewModelScope.launch {
+            Log.i(TAG, "Bitmap analysis loop started")
+            while (isActive) {
+                // getBitmap() must be called on main thread
+                val preview = previewViewRef
+                val bitmap = preview?.bitmap
+                if (bitmap != null) {
+                    // Process off main thread
+                    launch(Dispatchers.Default) {
+                        val deviceRot = orientationListener.deviceRotation
+                        val rotated = if (deviceRot != 0) {
+                            val matrix = Matrix().apply { postRotate(deviceRot.toFloat()) }
+                            val r = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+                            if (r !== bitmap) bitmap.recycle()
+                            r
+                        } else bitmap
+
+                        objectTracker.processBitmap(rotated)
+                    }
+                }
+                delay(BITMAP_ANALYSIS_INTERVAL_MS)
+            }
+            Log.i(TAG, "Bitmap analysis loop stopped")
+        }
+    }
+
+    private fun stopBitmapAnalysis() {
+        bitmapAnalysisJob?.cancel()
+        bitmapAnalysisJob = null
+    }
+
     override fun onCleared() {
         super.onCleared()
+        stopBitmapAnalysis()
         orientationListener.stop()
         objectTracker.shutdown()
         hapticManager.shutdown()

--- a/app/src/main/java/com/haptictrack/zoom/ZoomController.kt
+++ b/app/src/main/java/com/haptictrack/zoom/ZoomController.kt
@@ -4,10 +4,36 @@ import android.graphics.RectF
 
 class ZoomController(
     private val targetFrameOccupancy: Float = 0.15f,
-    private val zoomSpeed: Float = 0.05f
+    private val zoomSpeed: Float = 0.10f
 ) {
 
     private var currentZoom = 1f
+
+    /** When true, [calculateZoom] returns the current zoom unchanged (manual pinch active). */
+    var manualOverride: Boolean = false
+        private set
+
+    private var manualOverrideExpiry: Long = 0L
+
+    companion object {
+        /** Object touching frame edge — actively zoom out. */
+        private const val CLIP_THRESHOLD = 0.02f
+        /** Object near frame edge — stop zooming in. */
+        private const val EDGE_MARGIN = 0.08f
+        /** How long manual zoom holds after the last pinch gesture (ms). */
+        private const val MANUAL_OVERRIDE_DURATION_MS = 2000L
+    }
+
+    /**
+     * Set zoom directly from a pinch gesture.
+     * Activates manual override that pauses auto-zoom for [MANUAL_OVERRIDE_DURATION_MS].
+     */
+    fun setManualZoom(ratio: Float, minZoom: Float, maxZoom: Float): Float {
+        currentZoom = ratio.coerceIn(minZoom, maxZoom)
+        manualOverride = true
+        manualOverrideExpiry = System.currentTimeMillis() + MANUAL_OVERRIDE_DURATION_MS
+        return currentZoom
+    }
 
     /**
      * Calculate the desired zoom ratio based on the subject's bounding box.
@@ -18,6 +44,12 @@ class ZoomController(
      * @return Target zoom ratio
      */
     fun calculateZoom(boundingBox: RectF, minZoom: Float, maxZoom: Float): Float {
+        // Check if manual override has expired
+        if (manualOverride && System.currentTimeMillis() > manualOverrideExpiry) {
+            manualOverride = false
+        }
+        if (manualOverride) return currentZoom
+
         val boxArea = boundingBox.width() * boundingBox.height()
         val targetArea = targetFrameOccupancy
 
@@ -40,13 +72,6 @@ class ZoomController(
 
         currentZoom = (currentZoom + zoomAdjustment).coerceIn(minZoom, maxZoom)
         return currentZoom
-    }
-
-    companion object {
-        /** Object touching frame edge — actively zoom out. */
-        private const val CLIP_THRESHOLD = 0.02f
-        /** Object near frame edge — stop zooming in. */
-        private const val EDGE_MARGIN = 0.08f
     }
 
     /**
@@ -75,5 +100,9 @@ class ZoomController(
 
     fun reset() {
         currentZoom = 1f
+        manualOverride = false
     }
+
+    /** Current zoom level (for pinch gesture to use as baseline). */
+    fun getCurrentZoom(): Float = currentZoom
 }

--- a/app/src/test/java/com/haptictrack/zoom/ZoomControllerTest.kt
+++ b/app/src/test/java/com/haptictrack/zoom/ZoomControllerTest.kt
@@ -151,4 +151,48 @@ class ZoomControllerTest {
         val proximity = zoom.calculateEdgeProximity(box)
         assertTrue("Corner object should have ~1.0 proximity, got $proximity", proximity > 0.8f)
     }
+
+    // --- Manual zoom (pinch-to-zoom) ---
+
+    @Test
+    fun `manual zoom sets exact ratio`() {
+        val result = zoom.setManualZoom(2.5f, minZoom = 1f, maxZoom = 5f)
+        assertEquals(2.5f, result, 0.001f)
+        assertEquals(2.5f, zoom.getCurrentZoom(), 0.001f)
+    }
+
+    @Test
+    fun `manual zoom clamps to min and max`() {
+        assertEquals(1f, zoom.setManualZoom(0.5f, minZoom = 1f, maxZoom = 5f), 0.001f)
+        assertEquals(5f, zoom.setManualZoom(10f, minZoom = 1f, maxZoom = 5f), 0.001f)
+    }
+
+    @Test
+    fun `manual zoom pauses auto-zoom`() {
+        zoom.setManualZoom(3f, minZoom = 1f, maxZoom = 5f)
+        assertTrue("Manual override should be active", zoom.manualOverride)
+
+        // Auto-zoom should return current zoom unchanged
+        val smallBox = RectF(0.49f, 0.49f, 0.51f, 0.51f) // would normally zoom in
+        val result = zoom.calculateZoom(smallBox, minZoom = 1f, maxZoom = 5f)
+        assertEquals("Auto-zoom should be paused at manual level", 3f, result, 0.001f)
+    }
+
+    @Test
+    fun `reset clears manual override`() {
+        zoom.setManualZoom(3f, minZoom = 1f, maxZoom = 5f)
+        assertTrue(zoom.manualOverride)
+        zoom.reset()
+        assertFalse("Reset should clear manual override", zoom.manualOverride)
+        assertEquals(1f, zoom.getCurrentZoom(), 0.001f)
+    }
+
+    @Test
+    fun `auto-zoom continues from manual zoom level after override expires`() {
+        zoom.setManualZoom(2f, minZoom = 1f, maxZoom = 5f)
+        // Simulate expiry by using a zoom controller with expired override
+        // (In real code, System.currentTimeMillis() advances past the expiry)
+        // We can't easily mock time, so test that getCurrentZoom reflects manual level
+        assertEquals(2f, zoom.getCurrentZoom(), 0.001f)
+    }
 }

--- a/app/src/test/java/com/haptictrack/zoom/ZoomControllerTest.kt
+++ b/app/src/test/java/com/haptictrack/zoom/ZoomControllerTest.kt
@@ -151,4 +151,39 @@ class ZoomControllerTest {
         val proximity = zoom.calculateEdgeProximity(box)
         assertTrue("Corner object should have ~1.0 proximity, got $proximity", proximity > 0.8f)
     }
+
+    // --- Manual zoom (pinch-to-zoom) ---
+
+    @Test
+    fun `manual zoom sets exact ratio`() {
+        val result = zoom.setManualZoom(2.5f, minZoom = 1f, maxZoom = 5f)
+        assertEquals(2.5f, result, 0.001f)
+        assertEquals(2.5f, zoom.getCurrentZoom(), 0.001f)
+    }
+
+    @Test
+    fun `manual zoom clamps to min and max`() {
+        assertEquals(1f, zoom.setManualZoom(0.5f, minZoom = 1f, maxZoom = 5f), 0.001f)
+        assertEquals(5f, zoom.setManualZoom(10f, minZoom = 1f, maxZoom = 5f), 0.001f)
+    }
+
+    @Test
+    fun `manual zoom pauses auto-zoom`() {
+        zoom.setManualZoom(3f, minZoom = 1f, maxZoom = 5f)
+        assertTrue("Manual override should be active", zoom.manualOverride)
+
+        // Auto-zoom should return current zoom unchanged
+        val smallBox = RectF(0.49f, 0.49f, 0.51f, 0.51f) // would normally zoom in
+        val result = zoom.calculateZoom(smallBox, minZoom = 1f, maxZoom = 5f)
+        assertEquals("Auto-zoom should be paused at manual level", 3f, result, 0.001f)
+    }
+
+    @Test
+    fun `reset clears manual override`() {
+        zoom.setManualZoom(3f, minZoom = 1f, maxZoom = 5f)
+        assertTrue(zoom.manualOverride)
+        zoom.reset()
+        assertFalse("Reset should clear manual override", zoom.manualOverride)
+        assertEquals(1f, zoom.getCurrentZoom(), 0.001f)
+    }
 }

--- a/app/src/test/java/com/haptictrack/zoom/ZoomControllerTest.kt
+++ b/app/src/test/java/com/haptictrack/zoom/ZoomControllerTest.kt
@@ -151,48 +151,4 @@ class ZoomControllerTest {
         val proximity = zoom.calculateEdgeProximity(box)
         assertTrue("Corner object should have ~1.0 proximity, got $proximity", proximity > 0.8f)
     }
-
-    // --- Manual zoom (pinch-to-zoom) ---
-
-    @Test
-    fun `manual zoom sets exact ratio`() {
-        val result = zoom.setManualZoom(2.5f, minZoom = 1f, maxZoom = 5f)
-        assertEquals(2.5f, result, 0.001f)
-        assertEquals(2.5f, zoom.getCurrentZoom(), 0.001f)
-    }
-
-    @Test
-    fun `manual zoom clamps to min and max`() {
-        assertEquals(1f, zoom.setManualZoom(0.5f, minZoom = 1f, maxZoom = 5f), 0.001f)
-        assertEquals(5f, zoom.setManualZoom(10f, minZoom = 1f, maxZoom = 5f), 0.001f)
-    }
-
-    @Test
-    fun `manual zoom pauses auto-zoom`() {
-        zoom.setManualZoom(3f, minZoom = 1f, maxZoom = 5f)
-        assertTrue("Manual override should be active", zoom.manualOverride)
-
-        // Auto-zoom should return current zoom unchanged
-        val smallBox = RectF(0.49f, 0.49f, 0.51f, 0.51f) // would normally zoom in
-        val result = zoom.calculateZoom(smallBox, minZoom = 1f, maxZoom = 5f)
-        assertEquals("Auto-zoom should be paused at manual level", 3f, result, 0.001f)
-    }
-
-    @Test
-    fun `reset clears manual override`() {
-        zoom.setManualZoom(3f, minZoom = 1f, maxZoom = 5f)
-        assertTrue(zoom.manualOverride)
-        zoom.reset()
-        assertFalse("Reset should clear manual override", zoom.manualOverride)
-        assertEquals(1f, zoom.getCurrentZoom(), 0.001f)
-    }
-
-    @Test
-    fun `auto-zoom continues from manual zoom level after override expires`() {
-        zoom.setManualZoom(2f, minZoom = 1f, maxZoom = 5f)
-        // Simulate expiry by using a zoom controller with expired override
-        // (In real code, System.currentTimeMillis() advances past the expiry)
-        // We can't easily mock time, so test that getCurrentZoom reflects manual level
-        assertEquals(2f, zoom.getCurrentZoom(), 0.001f)
-    }
 }


### PR DESCRIPTION
## Summary

- **Pinch-to-zoom** with 2s manual override that pauses auto-zoom, then resumes
- **Volume-down 3-stage cycle**: lock center object → start recording → stop + clear (fully hands-free)
- **4K video recording** via dynamic 2/3-stream switching — drops ImageAnalysis during recording, uses PreviewView.getBitmap() for tracking instead
- **Stealth mode**: black screen overlay, tracking + recording continue via hidden preview
- **Zoom level indicator**: always visible when tracking, fades after pinch in idle
- **Capture mode pill** (VIDEO/PHOTO) with swipe gesture
- Faster auto-zoom (0.05 → 0.10 per frame)
- Camera rebind resilience: prepareForRebind() forces search mode for instant recovery

### 4K recording approach

Camera hardware limits 3 concurrent streams to 720p. When recording starts, ImageAnalysis is unbound (2 streams → 4K video). Analysis frames come from `PreviewView.getBitmap()` downscaled to ~640px width (~30ms/frame). On recording stop, 3-stream mode resumes via Finalize callback.

| Mode | Streams | Video | Analysis |
|------|---------|-------|----------|
| Tracking | preview + analysis + video | 720p | ImageAnalysis |
| Recording | preview + video | **4K** | getBitmap() |
| Stealth | preview + video (hidden) | **4K** | getBitmap() |

### Tested on Xiaomi 13 Pro
- 3840x2160 @ 30fps confirmed during recording
- Tracking + re-acquisition verified via getBitmap path (sim=0.828-0.949)
- Stealth mode: lock → stealth → record → stop → exit all working

## Test plan

- [x] Pinch-to-zoom works in idle and locked states
- [x] Volume-down cycles: lock → record → stop+clear
- [x] Zoom indicator visible during tracking, fades in idle
- [x] 4K video output confirmed via ffprobe
- [x] Tracking continues during recording via getBitmap
- [x] Stealth mode: black screen, tracking works, record works
- [x] Mode switch recovery: object reacquired within 1-2 frames
- [x] All 175 unit tests pass
- [ ] Test with person tracking (face/re-ID during getBitmap mode)
- [ ] Test stealth mode with phone orientation changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)