### PR TITLE
Unify on SurfaceTexture pipeline, remove 3-stream mode (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ MVVM with a single-activity Compose UI. Two-tier tracking: visual tracker for fr
 
 ```
 CameraViewModel
-├── CameraManager              (CameraX: preview, image analysis, zoom, video capture)
+├── CameraManager              (CameraX: SurfaceTexture GL pipeline, zoom, video capture)
 ├── DeviceOrientationListener  (accelerometer: detects upside-down/landscape holds)
 ├── ObjectTracker              (orchestrates the tracking pipeline below)
 │   ├── VisualTracker          (OpenCV VitTracker: primary frame-to-frame pixel tracking)
@@ -90,7 +90,7 @@ CameraViewModel
 ### Data Flow
 
 **Normal tracking (object visible):**
-1. CameraX feeds frames to `ObjectTracker` via `ImageAnalysis`
+1. CameraX feeds frames to `ObjectTracker` via the SurfaceTexture GL pipeline (always active, regardless of recording state)
 2. `DeviceOrientationListener` provides physical rotation → bitmap rotated to upright
 3. `VisualTracker` (VitTracker) updates the locked object's position by pixel correlation
 4. Detector runs in parallel to cross-check — if detector confirms the label at the tracker's box, tracking continues
@@ -113,16 +113,13 @@ CameraViewModel
   - Semantically guarded: COCO "person" can only become Man/Woman/Boy/Girl/Human face
 
 **Recording (4K mode):**
-1. `CameraManager.enterRecordingMode()` unbinds `ImageAnalysis`, rebinds with 2 streams (preview + video) → 4K
-2. `CameraViewModel` starts a coroutine loop calling `PreviewView.getBitmap()` on main thread
-3. Bitmap is downscaled to ~640px width, then fed to `ObjectTracker.processBitmap()` on `Dispatchers.Default`
-4. `processBitmap()` sets `deviceRotation=0` (getBitmap is display-oriented) and processes normally
-5. On recording stop, `Finalize` callback triggers `exitRecordingMode()` → rebinds 3 streams
-6. `prepareForRebind()` called before each rebind: stops VT, forces `framesLost=1` for instant re-acquisition
+1. Recording toggles VideoCapture on/off — no rebind or mode switching needed
+2. Frames always come from the SurfaceTexture GL pipeline, same as normal tracking
+3. 4K recording is always available since the pipeline uses only 2 streams (preview + video)
 
 **Stealth mode:**
-- Black overlay covers full-size PreviewView (preview must render at full size for `getBitmap()`)
-- Same 2-stream mode as recording — 4K video + getBitmap analysis
+- Black overlay covers the preview — purely a UI layer (opaque black Box in Compose)
+- SurfaceTexture pipeline provides frames regardless of UI visibility
 - Volume-down cycle still works: lock → record → stop+clear
 
 **Display:**
@@ -279,7 +276,7 @@ Position (50%, decays) + size (25%) + base bonus (25%). All survivors already pa
 **Recently merged to master:**
 - PR #42 — GPU delegate for all models, FP16 detector, adaptive frame skip, stealth mode, dependency bumps
 - PR #40 — Regression baseline scenarios with quantitative thresholds
-- PR #37 — Manual camera controls: pinch zoom, 4K recording via 2/3-stream switching, stealth mode, volume-down hands-free cycle
+- PR #37 — Manual camera controls: pinch zoom, 4K recording, stealth mode, volume-down hands-free cycle
 - PR #36 — Person identity: face embedding (MobileFaceNet) + body re-ID (OSNet x1.0)
 - PR #31 — Cascade scoring refactor (#30 phases 1+2), scenario recorder + replay harness
 - PR #29 — Two-stage detection (EfficientDet-Lite2 + YOLOv8n-oiv7 label enrichment)
@@ -341,11 +338,11 @@ Camera image aspect ratio differs from phone screen. All bounding box rendering 
 ### Confidence threshold at 50% (decided 2026-04-12)
 Both MediaPipe's detector and `DetectionFilter` use 0.5 minimum confidence.
 
-### Dynamic 2/3-stream switching for 4K recording (decided 2026-04-17)
-Camera hardware (Xiaomi 13 Pro) limits 3 concurrent streams (preview + analysis + video) to 720p. Dropping ImageAnalysis gives 2 streams → 4K. During recording, analysis frames come from `PreviewView.getBitmap()` downscaled to ~640px width (~30ms/frame vs ~500ms at native 1440x3200). Key gotchas: getBitmap must run on main thread, returns rendered pixel size (1dp view = 4x4px), image is display-oriented (deviceRot=0). VideoCapture must be recreated on each rebind to avoid resolution mismatch. `prepareForRebind()` forces search mode for instant recovery.
+### Unified SurfaceTexture pipeline (decided 2026-04-23, replaces 2/3-stream switching)
+Always uses 2-stream mode (SurfaceTexture + VideoCapture). Frames for tracking come from the GL pipeline via SurfaceTexture, not ImageAnalysis. Recording just toggles VideoCapture on/off — no rebind, no mode switching, no `prepareForRebind()`. This replaced the old dynamic 2/3-stream switching where ImageAnalysis was dropped during recording and `PreviewView.getBitmap()` was used as a fallback frame source. The unified pipeline is simpler and always delivers 4K-capable streams.
 
-### Stealth mode: hidden preview with black overlay (decided 2026-04-17)
-PreviewView must render at full size for `getBitmap()` to return usable frames. A 1dp preview returns 4x4px bitmaps. Solution: keep preview full-size, overlay with opaque black Box. Preview still processes frames, `getBitmap()` returns full resolution, user sees black screen with controls.
+### Stealth mode: black overlay over SurfaceTexture preview (decided 2026-04-17, updated 2026-04-23)
+Opaque black Box overlays the preview in Compose. SurfaceTexture pipeline provides frames regardless of UI visibility, so stealth is purely a UI concern. User sees black screen with controls.
 
 ### Volume-down hands-free cycle (decided 2026-04-17)
 Three-stage cycle on volume-down: idle → lock on center object, tracking → start recording, recording → stop recording + clear. Enables fully hands-free operation: point camera, press volume-down three times.
@@ -510,7 +507,7 @@ All in constructor defaults — no settings UI yet:
 - [x] Haptic feedback (continuous pulse, edge intensity, stop on lost)
 - [x] Auto-zoom from bounding box + pinch-to-zoom with manual override
 - [x] Volume-down hands-free cycle: lock center → record → stop+clear
-- [x] 4K video recording via dynamic 2/3-stream switching
+- [x] 4K video recording (unified SurfaceTexture pipeline)
 - [x] Stealth mode (true stealth: blank screen, tap to exit, volume-down only)
 - [x] All-orientation support (portrait, landscape, upside down) with hysteresis
 - [x] GPU delegate for all 9 models (FP16 detector + FP32 others on Adreno 740)

--- a/app/src/main/java/com/haptictrack/camera/CameraManager.kt
+++ b/app/src/main/java/com/haptictrack/camera/CameraManager.kt
@@ -7,11 +7,8 @@ import android.util.Log
 import androidx.camera.core.CameraControl
 import androidx.camera.core.CameraInfo
 import androidx.camera.core.CameraSelector
-import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.core.resolutionselector.ResolutionSelector
-import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.video.FallbackStrategy
 import androidx.camera.video.Quality
 import androidx.camera.video.QualitySelector
@@ -21,7 +18,6 @@ import androidx.camera.view.PreviewView
 import androidx.lifecycle.LifecycleOwner
 import android.os.Handler
 import android.os.Looper
-import android.util.Size
 import java.util.concurrent.Executors
 
 class CameraManager(private val context: Context) {
@@ -48,34 +44,16 @@ class CameraManager(private val context: Context) {
     var isFrontCamera: Boolean = false
         private set
 
-    /** When true, ImageAnalysis is unbound to free a stream for higher video resolution. */
-    private var recordingMode: Boolean = false
-
-    /** Whether ImageAnalysis is currently active (false during recording). */
-    var analysisActive: Boolean = true
-        private set
-
-    /** Reads frames from Preview surface via OpenGL during recording mode. */
+    /** Reads frames from Preview surface via OpenGL. Always active. */
     private var frameReader: SurfaceTextureFrameReader? = null
 
-    /** Callback for frames read from the Preview surface during recording (processing thread). */
-    var onRecordingFrame: ((android.graphics.Bitmap) -> Unit)? = null
+    /** Callback for analysis frames from SurfaceTexture (processing thread, ~10-12fps). */
+    var onAnalysisFrame: ((android.graphics.Bitmap) -> Unit)? = null
 
-    /** Callback for viewfinder display frames during recording (GL thread, ~29fps). */
+    /** Callback for viewfinder display frames from SurfaceTexture (GL thread, ~29fps). */
     var onViewfinderFrame: ((android.graphics.Bitmap) -> Unit)? = null
 
     val preview = Preview.Builder().build()
-
-    val imageAnalysis: ImageAnalysis = ImageAnalysis.Builder()
-        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-        .setResolutionSelector(
-            ResolutionSelector.Builder()
-                .setResolutionStrategy(
-                    ResolutionStrategy(Size(854, 640), ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER_THEN_HIGHER)
-                )
-                .build()
-        )
-        .build()
 
     private val videoExecutor = Executors.newSingleThreadExecutor()
     var videoCapture = createVideoCapture()
@@ -122,29 +100,10 @@ class CameraManager(private val context: Context) {
     }
 
     /**
-     * Switch to recording mode (2 streams: preview + video → higher video resolution).
-     * Analysis frames must be obtained via PreviewView.getBitmap().
+     * Rebind camera use cases. Always uses 2-stream (Preview + VideoCapture) with
+     * SurfaceTextureFrameReader providing both analysis and viewfinder frames.
+     * No mode switching — recording is just toggling VideoCapture on/off.
      */
-    fun enterRecordingMode() {
-        if (recordingMode) return
-        recordingMode = true
-        val owner = lifecycleOwnerRef ?: return
-        val view = previewViewRef ?: return
-        bindUseCases(owner, view)
-    }
-
-    /**
-     * Switch back to tracking mode (3 streams: preview + analysis + video).
-     * ImageAnalysis provides full-quality frames for detection.
-     */
-    fun exitRecordingMode() {
-        if (!recordingMode) return
-        recordingMode = false
-        val owner = lifecycleOwnerRef ?: return
-        val view = previewViewRef ?: return
-        bindUseCases(owner, view)
-    }
-
     private fun bindUseCases(lifecycleOwner: LifecycleOwner, previewView: PreviewView) {
         val provider = cameraProvider ?: return
         provider.unbindAll()
@@ -153,58 +112,49 @@ class CameraManager(private val context: Context) {
         frameReader?.stop()
         frameReader = null
 
-        // Recreate VideoCapture to avoid resolution mismatch when switching modes
+        // Recreate VideoCapture for fresh recorder per session
         videoCapture = createVideoCapture()
 
         val selector = if (isFrontCamera) CameraSelector.DEFAULT_FRONT_CAMERA
                        else CameraSelector.DEFAULT_BACK_CAMERA
 
-        val camera = if (recordingMode) {
-            // 2 streams: preview + video → 4K video
-            // Preview goes to SurfaceTextureFrameReader for fast off-thread frame capture
-            // instead of PreviewView.getBitmap() (slow, main-thread, 7-10fps)
-            preview.surfaceProvider = Preview.SurfaceProvider { request ->
-                val inputSize = request.resolution // camera's native buffer size (landscape, e.g. 1600x1200)
-                // Output in portrait at analysis resolution.
-                // Camera outputs landscape; transform matrix rotates 90°.
-                // So output width = min dim scaled, height = max dim scaled.
-                val analysisShort = 640 // short edge of output
-                val aspect = inputSize.width.toFloat() / inputSize.height
-                val analysisLong = (analysisShort * aspect).toInt()
-                // Portrait: width=short, height=long
-                val outW = analysisShort
-                val outH = analysisLong
-                Log.i(TAG, "SurfaceTexture: input=${inputSize}, output=${outW}x${outH}")
+        // Always route Preview to SurfaceTextureFrameReader for fast off-thread frame capture.
+        // 2-stream binding (preview + video) enables 4K recording.
+        preview.surfaceProvider = Preview.SurfaceProvider { request ->
+            val inputSize = request.resolution // camera's native buffer size (landscape, e.g. 1600x1200)
+            // Output in portrait at analysis resolution.
+            // Camera outputs landscape; transform matrix rotates 90°.
+            // So output width = min dim scaled, height = max dim scaled.
+            val analysisShort = 640 // short edge of output
+            val aspect = inputSize.width.toFloat() / inputSize.height
+            val analysisLong = (analysisShort * aspect).toInt()
+            // Portrait: width=short, height=long
+            val outW = analysisShort
+            val outH = analysisLong
+            Log.i(TAG, "SurfaceTexture: input=${inputSize}, output=${outW}x${outH}")
 
-                val reader = SurfaceTextureFrameReader(
-                    inputWidth = inputSize.width,
-                    inputHeight = inputSize.height,
-                    outputWidth = outW,
-                    outputHeight = outH,
-                    onFrame = { bitmap -> onRecordingFrame?.invoke(bitmap) },
-                    onViewfinderFrame = { bitmap -> onViewfinderFrame?.invoke(bitmap) }
-                )
-                val readerSurface = reader.start()
-                frameReader = reader
+            val reader = SurfaceTextureFrameReader(
+                inputWidth = inputSize.width,
+                inputHeight = inputSize.height,
+                outputWidth = outW,
+                outputHeight = outH,
+                onFrame = { bitmap -> onAnalysisFrame?.invoke(bitmap) },
+                onViewfinderFrame = { bitmap -> onViewfinderFrame?.invoke(bitmap) }
+            )
+            val readerSurface = reader.start()
+            frameReader = reader
 
-                request.provideSurface(readerSurface, java.util.concurrent.Executors.newSingleThreadExecutor()) { result ->
-                    Log.d(TAG, "Preview surface result: ${result.resultCode}")
-                }
+            request.provideSurface(readerSurface, Executors.newSingleThreadExecutor()) { result ->
+                Log.d(TAG, "Preview surface result: ${result.resultCode}")
             }
-            provider.bindToLifecycle(lifecycleOwner, selector, preview, videoCapture)
-        } else {
-            // 3 streams: preview + analysis + video → full-quality analysis
-            preview.surfaceProvider = previewView.surfaceProvider
-            provider.bindToLifecycle(lifecycleOwner, selector, preview, imageAnalysis, videoCapture)
         }
-        analysisActive = !recordingMode
+        val camera = provider.bindToLifecycle(lifecycleOwner, selector, preview, videoCapture)
 
         cameraControl = camera.cameraControl
         cameraInfo = camera.cameraInfo
 
         val previewRes = preview.resolutionInfo?.resolution
-        val analysisRes = if (!recordingMode) imageAnalysis.resolutionInfo?.resolution else null
-        Log.i(TAG, "Bound use cases — preview: $previewRes, analysis: $analysisRes, frameReader: ${frameReader != null}, mode: ${if (recordingMode) "recording (2-stream)" else "tracking (3-stream)"}")
+        Log.i(TAG, "Bound use cases — preview: $previewRes, frameReader: ${frameReader != null}, mode: always SurfaceTexture (2-stream)")
     }
 
     fun setZoomRatio(ratio: Float) {

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -2,11 +2,8 @@ package com.haptictrack.tracking
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.Matrix
 import android.graphics.PointF
 import android.graphics.RectF
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageProxy
 import com.google.mediapipe.framework.image.BitmapImageBuilder
 import com.google.mediapipe.tasks.core.BaseOptions
 import com.google.mediapipe.tasks.core.Delegate
@@ -212,29 +209,16 @@ class ObjectTracker(
         contourFrameCount = 0
     }
 
-    val analyzer = ImageAnalysis.Analyzer { imageProxy ->
-        processImage(imageProxy)
-    }
-
     /**
      * Process a display-oriented bitmap from PreviewView.getBitmap().
      * Unlike the ImageProxy path, the bitmap is already in screen orientation —
      * no rotation is applied, and detector coordinates are used as-is (deviceRot=0).
      */
     fun processBitmap(bitmap: Bitmap) {
-        processBitmapInternal(bitmap, deviceRotation = 0, imageProxy = null)
+        processBitmapInternal(bitmap, deviceRotation = 0)
     }
 
-    private fun processImage(imageProxy: ImageProxy) {
-        val bitmap = imageProxyToBitmap(imageProxy)
-        if (bitmap == null) {
-            imageProxy.close()
-            return
-        }
-        processBitmapInternal(bitmap, deviceRotation = deviceRotationProvider?.invoke() ?: 0, imageProxy = imageProxy)
-    }
-
-    private fun processBitmapInternal(bitmap: Bitmap, deviceRotation: Int, imageProxy: ImageProxy?) {
+    private fun processBitmapInternal(bitmap: Bitmap, deviceRotation: Int) {
         val frameWidth = bitmap.width
         val frameHeight = bitmap.height
 
@@ -538,7 +522,6 @@ class ObjectTracker(
             lastDetections = displayObjects
             onDetectionResult?.invoke(displayObjects, lockedObject, frameWidth, frameHeight, cachedContour)
         } finally {
-            imageProxy?.close()
             bitmap.recycle()
         }
     }
@@ -563,26 +546,6 @@ class ObjectTracker(
                 confidence = detection.categories().firstOrNull()?.score() ?: 0f
             )
         }
-    }
-
-    private fun imageProxyToBitmap(imageProxy: ImageProxy): Bitmap? {
-        val bitmap = imageProxy.toBitmap()
-
-        // CameraX rotationDegrees assumes the display matches the activity's
-        // declared orientation (portrait). It does NOT account for the user
-        // physically holding the phone in landscape or upside down.
-        // We add the physical device rotation so the image fed to the detector
-        // is always upright relative to the real world.
-        val cameraRotation = imageProxy.imageInfo.rotationDegrees
-        val deviceRot = deviceRotationProvider?.invoke() ?: 0
-        val rotation = (cameraRotation + deviceRot) % 360
-
-        if (rotation == 0) return bitmap
-
-        val matrix = Matrix().apply { postRotate(rotation.toFloat()) }
-        val rotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
-        if (rotated !== bitmap) bitmap.recycle()
-        return rotated
     }
 
     private fun captureDebugFrame(

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -176,22 +176,6 @@ class ObjectTracker(
         }
     }
 
-    /**
-     * Prepare for a camera rebind. Stops visual tracker and forces
-     * re-acquisition engine into search mode so it recovers on the
-     * first frame after the camera restarts.
-     */
-    fun prepareForRebind() {
-        if (!reacquisition.isLocked) return
-        visualTracker.stop()
-        vtUnconfirmedFrames = 0
-        vtFrameCounter = 0
-        velocityEstimator.reset()
-        pendingEmbeddings?.cancel(true)
-        pendingEmbeddings = null
-        reacquisition.prepareForRebind()
-    }
-
     fun clearLock() {
         scenarioRecorder.recordEvent("CLEAR")
         scenarioRecorder.stop()

--- a/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
@@ -400,17 +400,6 @@ class ReacquisitionEngine(
         lastKnownVelocityY = vy
     }
 
-    /**
-     * Prepare for a camera rebind that will interrupt the frame stream.
-     * Forces into search mode so the first frame after rebind triggers re-acquisition
-     * using the full embedding gallery. Call before unbinding camera use cases.
-     */
-    fun prepareForRebind() {
-        if (!isLocked) return
-        framesLost = 1
-        android.util.Log.i("Reacq", "REBIND_PREPARE — forced search mode, gallery=${embeddingGallery.size}")
-    }
-
     internal fun positionConfidence(): Float {
         if (framesLost <= 0) return 1f
         return (1f - framesLost.toFloat() / positionDecayFrames).coerceIn(0f, 1f)

--- a/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
@@ -283,10 +283,10 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                     }
             )
 
-            // Viewfinder from analysis frames during recording.
-            // Preview surface goes to SurfaceTexture for fast frame reading,
-            // so PreviewView is frozen. We render the analysis bitmap instead.
-            if (uiState.isRecording && !uiState.stealthMode) {
+            // Viewfinder from SurfaceTexture GL thread — always active.
+            // Preview surface goes to SurfaceTextureFrameReader, so PreviewView
+            // shows nothing. We render the GL viewfinder bitmap instead.
+            if (!uiState.stealthMode) {
                 val viewfinderBmp by viewModel.viewfinderBitmap.collectAsStateWithLifecycle()
                 viewfinderBmp?.let { bmp ->
                     Image(

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -12,20 +12,17 @@ import com.haptictrack.camera.CameraManager
 import com.haptictrack.camera.DeviceOrientationListener
 import com.haptictrack.camera.RecordingManager
 import com.haptictrack.haptics.HapticFeedbackManager
-import com.haptictrack.tracking.CaptureMode
 import com.haptictrack.tracking.ObjectTracker
 import com.haptictrack.tracking.TrackedObject
 import com.haptictrack.tracking.TrackingStatus
 import com.haptictrack.tracking.TrackingUiState
+import com.haptictrack.tracking.CaptureMode
 import com.haptictrack.zoom.ZoomController
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class CameraViewModel(application: Application) : AndroidViewModel(application) {
@@ -40,22 +37,14 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
     private val _uiState = MutableStateFlow(TrackingUiState())
     val uiState: StateFlow<TrackingUiState> = _uiState.asStateFlow()
 
-    /** Analysis frame for viewfinder during recording (when Preview goes to SurfaceTexture). */
+    /** Viewfinder frame from SurfaceTexture GL thread — always active. */
     private val _viewfinderBitmap = MutableStateFlow<android.graphics.Bitmap?>(null)
     val viewfinderBitmap: StateFlow<android.graphics.Bitmap?> = _viewfinderBitmap.asStateFlow()
-
-    /** Coroutine job for getBitmap() analysis loop during recording. */
-    private var bitmapAnalysisJob: Job? = null
-    private var previewViewRef: PreviewView? = null
 
     companion object {
         private const val TAG = "CameraVM"
         /** Tap target padding in normalized coordinates (~3% of screen on each side). */
         private const val TAP_PADDING = 0.03f
-        /** Target interval between getBitmap() analysis frames (ms). */
-        private const val BITMAP_ANALYSIS_INTERVAL_MS = 50L // ~20fps
-        /** Downscale getBitmap to this width for analysis (matches ImageAnalysis res). */
-        private const val ANALYSIS_TARGET_WIDTH = 640
     }
 
     /** Smooths idle detections by keeping objects alive for a few frames after they disappear. */
@@ -127,23 +116,17 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
             }
 
             objectTracker = tracker
-            cameraManager.imageAnalysis.setAnalyzer(
-                java.util.concurrent.Executors.newSingleThreadExecutor(),
-                tracker.analyzer
-            )
-            // During recording, frames come from SurfaceTextureFrameReader instead of ImageAnalysis.
-            // Viewfinder updates at GL rate (~29fps) — always smooth, independent of processing.
-            // Processing thread picks up latest frame when ready (~10-12fps), naturally drops frames.
+            // Analysis frames always come from SurfaceTexture — no ImageAnalysis needed.
+            cameraManager.onAnalysisFrame = { bitmap ->
+                if (isTrackerReady) {
+                    tracker.processBitmap(bitmap)
+                }
+            }
             cameraManager.onViewfinderFrame = { bitmap ->
                 // Don't recycle previous bitmaps — Compose's RenderThread may still be
                 // drawing them asynchronously even after StateFlow emits a new value.
                 // At 480×640 ARGB (~1.2MB each), GC handles this fine on 8GB+ devices.
                 _viewfinderBitmap.value = bitmap
-            }
-            cameraManager.onRecordingFrame = { bitmap ->
-                if (isTrackerReady) {
-                    tracker.processBitmap(bitmap)
-                }
             }
             _uiState.update { it.copy(isReady = true) }
             Log.i(TAG, "ML models loaded, tracking ready")
@@ -151,7 +134,6 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun startCamera(lifecycleOwner: LifecycleOwner, previewView: PreviewView) {
-        previewViewRef = previewView
         cameraManager.startCamera(lifecycleOwner, previewView)
     }
 
@@ -270,17 +252,11 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
     fun toggleStealthMode() {
         val entering = !_uiState.value.stealthMode
         if (!entering && _uiState.value.isRecording) {
-            // Stop recording before exiting stealth — rebind would kill VideoCapture
             recordingManager.stopRecording()
         }
         _uiState.update { it.copy(stealthMode = entering) }
-        objectTracker.prepareForRebind()
-        if (entering) {
-            cameraManager.enterRecordingMode()
-            // Frame reader in CameraManager handles analysis via onRecordingFrame
-        } else {
-            cameraManager.exitRecordingMode()
-        }
+        // No camera rebind needed — SurfaceTexture pipeline is always active.
+        // Stealth is purely a UI overlay change.
     }
 
     fun switchCamera() {
@@ -304,73 +280,21 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         if (recordingManager.isRecording) {
             recordingManager.stopRecording()
         } else {
-            if (!_uiState.value.stealthMode) {
-                objectTracker.prepareForRebind()
-                cameraManager.enterRecordingMode()
-                // Frame reader in CameraManager handles analysis via onRecordingFrame
-            }
+            // No camera rebind needed — SurfaceTexture pipeline is always active.
+            // Just start recording on the existing VideoCapture.
             recordingManager.startRecording(cameraManager.videoCapture) { event ->
                 when (event) {
                     is VideoRecordEvent.Start ->
                         _uiState.update { it.copy(isRecording = true) }
-                    is VideoRecordEvent.Finalize -> {
+                    is VideoRecordEvent.Finalize ->
                         _uiState.update { it.copy(isRecording = false) }
-                        _viewfinderBitmap.value = null
-                        if (!_uiState.value.stealthMode) {
-                            objectTracker.prepareForRebind()
-                            cameraManager.exitRecordingMode()
-                        }
-                    }
                 }
             }
         }
-    }
-
-    /**
-     * Start a coroutine loop that pulls bitmaps from PreviewView for analysis.
-     * Used during recording when ImageAnalysis is unbound.
-     */
-    private fun startBitmapAnalysis() {
-        bitmapAnalysisJob?.cancel()
-        bitmapAnalysisJob = viewModelScope.launch {
-            Log.i(TAG, "Bitmap analysis loop started")
-            while (isActive) {
-                // getBitmap() must be called on main thread
-                val preview = previewViewRef
-                val bitmap = preview?.bitmap
-                if (bitmap != null) {
-                    kotlinx.coroutines.withContext(Dispatchers.Default) {
-                        // Downscale to ~640px wide to match ImageAnalysis resolution.
-                        // Full screen resolution (1440x3200) is 15x more pixels and
-                        // takes ~500ms per frame vs ~30ms at 640px.
-                        val scale = ANALYSIS_TARGET_WIDTH.toFloat() / bitmap.width
-                        val scaled = if (scale < 0.9f) {
-                            val w = (bitmap.width * scale).toInt()
-                            val h = (bitmap.height * scale).toInt()
-                            android.graphics.Bitmap.createScaledBitmap(bitmap, w, h, true).also {
-                                bitmap.recycle()
-                            }
-                        } else bitmap
-
-                        objectTracker.processBitmap(scaled)
-                    }
-                    kotlinx.coroutines.yield()
-                } else {
-                    delay(BITMAP_ANALYSIS_INTERVAL_MS)
-                }
-            }
-            Log.i(TAG, "Bitmap analysis loop stopped")
-        }
-    }
-
-    private fun stopBitmapAnalysis() {
-        bitmapAnalysisJob?.cancel()
-        bitmapAnalysisJob = null
     }
 
     override fun onCleared() {
         super.onCleared()
-        stopBitmapAnalysis()
         orientationListener.stop()
         if (isTrackerReady) objectTracker.shutdown()
         hapticManager.shutdown()


### PR DESCRIPTION
## Summary

- Always use 2-stream SurfaceTexture pipeline (Preview + VideoCapture). Removed the dual-mode architecture where tracking used 3-stream (Preview + ImageAnalysis + VideoCapture) and recording switched to 2-stream.
- Recording now just toggles VideoCapture on/off — no `unbindAll()`, no `prepareForRebind()`, no camera rebind. Eliminates #46 entirely.
- Stealth mode is purely a UI overlay change — no camera reconfiguration needed.
- Removed ~163 lines of dead code across 4 files: `ImageAnalysis` setup, `enterRecordingMode()`/`exitRecordingMode()`, `processImage(ImageProxy)`, `startBitmapAnalysis()`/`stopBitmapAnalysis()`, mode flags, and conditional viewfinder rendering.
- Updated CLAUDE.md to reflect the new architecture.

## Files changed

| File | Changes |
|------|---------|
| `CameraManager.kt` | Removed dual-mode logic, `imageAnalysis`, `recordingMode`/`analysisActive` flags. Always creates SurfaceTextureFrameReader. Renamed `onRecordingFrame` → `onAnalysisFrame`. |
| `CameraViewModel.kt` | Removed mode switching, `prepareForRebind()` for recording, dead code (`startBitmapAnalysis`, `processImage`). `toggleRecording()` just starts/stops. `toggleStealthMode()` is purely UI. |
| `CameraScreen.kt` | Viewfinder always renders from `viewfinderBitmap` (removed recording-only conditional). |
| `ObjectTracker.kt` | Removed `analyzer` property, `processImage(ImageProxy)`, `imageProxyToBitmap()`, ImageAnalysis imports. |
| `CLAUDE.md` | Replaced 3-stream/ImageAnalysis/mode-switching docs with unified pipeline description. |

## Test plan

- [x] 225+ unit tests pass
- [x] On-device video replay: 10/12 pass, 2 pre-existing flaky failures (mouse rotation detector coverage #53, person playground GPU non-determinism — passes on re-run)
- [x] Manual device test: tracking without recording, start/stop recording (seamless), stealth mode, volume-down cycle, camera switch — all working
- [x] SurfaceTexture confirmed active: `STFrameReader: GL thread produced 2069 frames`

Closes #48, closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)