### PR TITLE
Fix VT drift detection + embedding delivery (#45, #53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ app/src/main/java/com/haptictrack/
 │   ├── PersonAttributeClassifier.kt         # Crossroad-0230 + BlazeFace + age-gender
 │   ├── VisualTracker.kt                     # OpenCV VitTracker wrapper
 │   ├── FrameToFrameTracker.kt               # IoU-based detection ID assignment
-│   ├── DetectionFilter.kt                   # Noise removal (confidence, size, aspect ratio)
+│   ├── DetectionFilter.kt                   # Noise removal (confidence, size, aspect ratio; applied before scoring)
 │   ├── ScenarioRecorder.kt                  # JSON capture for replay testing + serialization helpers
 │   ├── DebugFrameCapture.kt                 # Annotated PNGs + session.log on tracking events
 │   ├── ObjectSegmenter.kt                   # magic_touch segmentation for masked crops
@@ -94,16 +94,18 @@ CameraViewModel
 2. `DeviceOrientationListener` provides physical rotation → bitmap rotated to upright
 3. `VisualTracker` (VitTracker) updates the locked object's position by pixel correlation
 4. Detector runs in parallel to cross-check — if detector confirms the label at the tracker's box, tracking continues
-5. If detector doesn't confirm for 10 frames → drift detected, visual tracker stopped
+5. Every 5 frames, the current VT crop is embedded and compared against the lock gallery — primary drift signal (catches drift even when the detector can't see the target)
+6. 3 consecutive template mismatches (sim < 0.4) OR 10 frames without detector confirmation → drift detected, visual tracker stopped
 
 **Re-acquisition (object lost):**
 1. Detector runs, `FrameToFrameTracker` assigns stable IDs via IoU matching
 2. `Yolov8Detector` enriches COCO labels with OIV7 labels (every 10th search frame)
-3. `AppearanceEmbedder` computes visual fingerprints for all candidates
-4. `ReacquisitionEngine` scores candidates: position (decays over time) + size + label (20% scoring factor, -0.5 penalty for mismatch) + appearance similarity + color histogram + person attributes
-5. Strong embedding match (>0.7 cosine similarity) overrides position/size hard thresholds
-6. Best candidate above `minScoreThreshold` becomes the new lock; visual tracker re-initializes
-7. `ScenarioRecorder` captures every frame's detections and events as JSON for replay testing
+3. `AppearanceEmbedder` computes visual fingerprints for all candidates (async pipeline; synchronous fallback for the closest same-category candidate when the async cache can't bridge across frames during rotation)
+4. `DetectionFilter` runs before scoring to strip phantom full-screen detections (area > 0.5) that EfficientDet produces during motion blur
+5. `ReacquisitionEngine` scores candidates: position (decays over time) + size + label (20% scoring factor, -0.5 penalty for mismatch) + appearance similarity + color histogram + person attributes
+6. Strong embedding match (>0.7 cosine similarity) overrides position/size hard thresholds
+7. Best candidate above `minScoreThreshold` becomes the new lock; visual tracker re-initializes
+8. `ScenarioRecorder` captures every frame's detections and events as JSON for replay testing
 
 **Two-stage detection:**
 - EfficientDet-Lite2 (COCO 80) runs every frame for reliable bounding boxes
@@ -274,6 +276,9 @@ Position (50%, decays) + size (25%) + base bonus (25%). All survivors already pa
 ## Current Work (may be stale — verify with git/GitHub)
 
 **Recently merged to master:**
+- PR #54 — Unify on SurfaceTexture pipeline, remove 3-stream mode (#48)
+- PR #52 — Identity: tentative confirmation, ratio test, gallery-relative threshold, online classifier (#50)
+- PR #44 — Velocity estimation + async embeddings + SurfaceTexture recording
 - PR #42 — GPU delegate for all models, FP16 detector, adaptive frame skip, stealth mode, dependency bumps
 - PR #40 — Regression baseline scenarios with quantitative thresholds
 - PR #37 — Manual camera controls: pinch zoom, 4K recording, stealth mode, volume-down hands-free cycle
@@ -295,8 +300,15 @@ Position (50%, decays) + size (25%) + base bonus (25%). All survivors already pa
 ### Two-stage detection: EfficientDet-Lite2 + YOLOv8n-oiv7 (decided 2026-04-17)
 EfficientDet-Lite2 runs every frame for reliable bounding boxes (person at 0.80-0.88 confidence). YOLOv8n-oiv7 runs on-demand to upgrade coarse COCO labels to finer OIV7 labels (601 classes). OIV7 splits "person" across sub-classes (Boy, Girl, Man, Woman) so no single class gets high confidence indoors — that's why YOLOv8 can't be the sole detector. Enrichment is semantically guarded: COCO "person" can only become Man/Woman/Boy/Girl/Human face, never furniture.
 
-### Two-tier tracking: VisualTracker + Detector (decided 2026-04-13)
-VitTracker (OpenCV) follows the locked object by pixel correlation — no classifier needed, very stable frame-to-frame. But it drifts when the object leaves frame. The detector + embedding pipeline handles re-acquisition. The visual tracker is cross-checked against the detector every frame; 10 consecutive unconfirmed frames triggers drift detection and handoff to re-acquisition.
+### Two-tier tracking: VisualTracker + Detector (decided 2026-04-13, revised 2026-04-24)
+VitTracker (OpenCV) follows the locked object by pixel correlation — no classifier needed, very stable frame-to-frame. But it drifts when the object leaves frame. The detector + embedding pipeline handles re-acquisition.
+
+**Drift detection uses two parallel signals:**
+1. **Template self-verification (primary)**: every 5 frames during VT tracking, embed the current VT crop (raw crop fallback, ~8ms) and compare to the lock gallery via `bestGallerySimilarity()`. 3 consecutive similarities below 0.4 (~0.5s) triggers drift. Detector-independent — catches drift even when the detector can't see the target (small objects, uniform surfaces, label flicker).
+2. **Detector cross-check (secondary)**: if the detector doesn't confirm the VT position for 10 consecutive frames, also triggers drift. Kept as a safety net for cases where the template somehow keeps matching but the object has moved.
+
+### Template self-verification rationale (decided 2026-04-24)
+The old approach (detector cross-check only) had a structural flaw: "detector found something elsewhere in the frame but not at VT position" was counted as drift evidence, even when the detector simply missed our object (common for small/uniform objects like a yellow bowl). This caused false drift kills on correctly-tracking VT. Research (TLD PAMI 2012, Stark ICCV 2021, DaSiamRPN ECCV 2018) consistently treats the tracker's own self-assessment as the primary drift signal, with the detector as a peer rather than a judge. Template self-verification directly measures "does this crop still look like the locked object" — the right question.
 
 ### COCO label stored alongside enriched label (decided 2026-04-17)
 `lockedCocoLabel` is stored at lock time alongside the enriched label. Label matching accepts either: a candidate labeled "potted plant" (COCO) matches a lock of "flowerpot" (OIV7) because the COCO parent is "potted plant". Without this, enrichment-timing mismatches cause the correct object to get the -0.5 label penalty.
@@ -360,11 +372,12 @@ When VitTracker is confident (>0.6) and has 5+ confirmed frames with 0 unconfirm
 | Tag | What it logs |
 |---|---|
 | `Reacq` | LOCK, LOST, SEARCH (with candidate scores + similarity), REACQUIRE (with hop count + sim), TIMEOUT, CLEAR, GIVE_UP, OVERRIDE (when embedding bypasses geometric filters) |
-| `VisualTracker` | INIT (tracker started), LOST (confidence dropped), DRIFT (unconfirmed frames exceeded threshold) |
+| `VisualTracker` | INIT (tracker started), LOST (confidence dropped), DRIFT (template mismatch OR unconfirmed frames exceeded), Template mismatch (per-check log when sim below threshold) |
 | `FTFTracker` | NEW (fresh ID assigned), MATCH (IoU match to previous frame) |
 | `Yolov8Det` | Enriched label results, no-enrichment cases |
 | `ScenarioRec` | Recording started/stopped, frame count |
-| `AppearEmbed` | Embedding failures |
+| `AppearEmbed` | Embedding failures, gallery additions |
+| `EmbedSync` | Synchronous embedding fallback fired for a candidate that missed the async cache |
 | `TFLiteGPU` | GPU delegate activation or CPU fallback per model |
 | `DebugCapture` | Saved debug frame filenames |
 
@@ -485,9 +498,13 @@ All in constructor defaults — no settings UI yet:
 | `MAX_GALLERY_SIZE` | ReacquisitionEngine | 12 | Maximum embeddings in the reference gallery |
 | `ENRICH_IOU_THRESHOLD` | Yolov8Detector | 0.3 | Min IoU to match YOLOv8 detection to EfficientDet box |
 | `minConfidence` | DetectionFilter | 0.5 | Minimum ML confidence to show detection |
+| `maxBoxArea` | DetectionFilter | 0.5 | Reject phantom full-screen detections (applied before scoring) |
 | `minIou` | FrameToFrameTracker | 0.2 | Minimum IoU to match across frames |
 | `MIN_CONFIDENCE` | VisualTracker | 0.5 | VitTracker confidence floor |
-| `VT_MAX_UNCONFIRMED` | ObjectTracker | 10 | Frames without detector confirmation → drift |
+| `VT_MAX_UNCONFIRMED` | ObjectTracker | 10 | Frames without detector confirmation → drift (secondary signal) |
+| `TEMPLATE_CHECK_INTERVAL` | ObjectTracker | 5 | Embed VT crop every N frames for self-verification |
+| `TEMPLATE_SIM_THRESHOLD` | ObjectTracker | 0.4 | Similarity below this = drift suspicion |
+| `TEMPLATE_MISMATCH_MAX` | ObjectTracker | 3 | Consecutive low-sim checks → drift (primary signal) |
 | `targetFrameOccupancy` | ZoomController | 0.15 | Target subject size as fraction of frame |
 | `zoomSpeed` | ZoomController | 0.05 | Zoom change per frame |
 | `scoreThreshold` | ObjectTracker (MediaPipe) | 0.5 | MediaPipe detector confidence cutoff |

--- a/app/src/main/java/com/haptictrack/tracking/DetectionFilter.kt
+++ b/app/src/main/java/com/haptictrack/tracking/DetectionFilter.kt
@@ -10,7 +10,7 @@ class DetectionFilter(
     /** Minimum bounding box area (normalized, 0..1). Rejects tiny slivers. */
     val minBoxArea: Float = 0.005f,
     /** Maximum bounding box area (normalized, 0..1). Rejects "whole frame" detections. */
-    val maxBoxArea: Float = 0.7f,
+    val maxBoxArea: Float = 0.5f,
     /** Minimum aspect ratio (width/height). Rejects extremely thin boxes. */
     val minAspectRatio: Float = 0.2f,
     /** Maximum aspect ratio (width/height). Rejects extremely wide boxes. */

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -436,7 +436,46 @@ class ObjectTracker(
                     })
                 }
 
-                merged
+                // --- Synchronous embedding fallback for candidates that missed the cache ---
+                // During rotation, IoU between consecutive frames drops below 0.3 so the
+                // async cache can't merge. Without embeddings, the ReacquisitionEngine's
+                // identity gate hard-rejects these candidates, causing multi-second gaps.
+                // Fix: compute embedding synchronously for the single best same-category
+                // candidate that has no embedding. One-time ~23ms cost per new candidate.
+                val withSyncFallback = if (reacquisition.hasEmbeddings) {
+                    val refBox = reacquisition.lastKnownBox
+                    val lockedIsPerson = reacquisition.lockedIsPerson
+                    // Find same-category candidates missing embeddings
+                    val needsSync = merged.filter { obj ->
+                        obj.embedding == null && obj.id >= 0 &&
+                            ((obj.label == "person") == lockedIsPerson)
+                    }
+                    if (needsSync.isNotEmpty() && refBox != null) {
+                        // Pick the closest one by center distance to last known position
+                        val best = needsSync.minByOrNull { obj ->
+                            val dx = obj.boundingBox.centerX() - refBox.centerX()
+                            val dy = obj.boundingBox.centerY() - refBox.centerY()
+                            dx * dx + dy * dy
+                        }!!
+                        // Compute embedding synchronously (raw crop fallback, ~8-23ms)
+                        val embResult = appearanceEmbedder.embedAndCrop(bitmap, best.boundingBox, fallback = true)
+                        val hist = if (embResult.maskedCrop != null) {
+                            val fullBox = RectF(0f, 0f, 1f, 1f)
+                            computeColorHistogram(embResult.maskedCrop, fullBox).also { embResult.maskedCrop.recycle() }
+                        } else computeColorHistogram(bitmap, best.boundingBox)
+                        if (embResult.embedding != null) {
+                            android.util.Log.d("EmbedSync", "Sync embedding for id=${best.id} label=${best.label}")
+                            merged.map { obj ->
+                                if (obj.id == best.id) obj.copy(
+                                    embedding = embResult.embedding,
+                                    colorHistogram = hist
+                                ) else obj
+                            }
+                        } else merged
+                    } else merged
+                } else merged
+
+                withSyncFallback
             } else {
                 pendingEmbeddings = null // clear when not searching
                 withLabels
@@ -446,11 +485,15 @@ class ObjectTracker(
             val wasSearching = reacquisition.isSearching
             val prevLost = reacquisition.framesLost
 
+            // Filter before scoring — removes phantom full-screen detections
+            // (e.g. "airplane" at [0,0,1,0.7]) that appear during rotation/motion blur.
+            val filtered = filter.filter(withEmbeddings)
+
             // Record frame for scenario replay (before processFrame consumes it)
-            scenarioRecorder.recordFrame(withEmbeddings)
+            scenarioRecorder.recordFrame(filtered)
 
             // Re-acquisition
-            val lockedObject = reacquisition.processFrame(withEmbeddings)
+            val lockedObject = reacquisition.processFrame(filtered)
 
             // Record events for scenario replay
             val nowLost = reacquisition.framesLost
@@ -482,7 +525,8 @@ class ObjectTracker(
             captureDebugFrame(bitmap, withEmbeddings, lockedObject, wasSearching, prevLost)
 
             // Filter for display
-            val displayObjects = filter.filter(withEmbeddings)
+            // Already filtered before processFrame — reuse for display
+            val displayObjects = filtered
 
             // Update contour on re-acquire or periodically (gated — disabled until UI uses it)
             if (contourEnabled) {

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -325,6 +325,9 @@ class ObjectTracker(
                     // lock gallery. Detector-independent, so it catches drift on small
                     // or uniform objects the detector struggles with. Skipped on
                     // detector-skip frames (no bitmap cost budget).
+                    //
+                    // Effective rate is every ~5 frames normally, ~10 frames when VT
+                    // frame skipping is active (skipDetector=true on alternate frames).
                     if (!skipDetector &&
                         reacquisition.hasEmbeddings &&
                         vtFrameCounter % TEMPLATE_CHECK_INTERVAL == 0) {
@@ -561,7 +564,10 @@ class ObjectTracker(
                 lastFrameDeviceRotation = deviceRotation
             }
 
-            // Debug frame capture on tracking events
+            // Debug frame capture on tracking events.
+            // Uses unfiltered `withEmbeddings` on purpose — debug overlays should
+            // show what the detector produced, including phantoms that the filter
+            // removed, so we can diagnose when the filter is too aggressive.
             captureDebugFrame(bitmap, withEmbeddings, lockedObject, wasSearching, prevLost)
 
             // Filter for display

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -56,6 +56,19 @@ class ObjectTracker(
     private val VT_ADAPTIVE_UNCONFIRMED_HIGH = 5      // ~165ms for fast subjects
     private val VT_ADAPTIVE_UNCONFIRMED_VERY_HIGH = 3  // ~100ms for very fast subjects
 
+    /**
+     * Template self-verification (issue #45, R3 from research):
+     * Every N frames during VT tracking, embed the current VT crop and compare
+     * it against the lock gallery. Low similarity means the crop no longer
+     * resembles the locked object → VT has drifted. Detector-independent,
+     * so it catches drift even when the detector can't see the target
+     * (small objects, uniform surfaces, label flicker).
+     */
+    private val TEMPLATE_CHECK_INTERVAL = 5    // embed VT crop every N frames
+    private val TEMPLATE_SIM_THRESHOLD = 0.4f  // below this = drift suspicion
+    private val TEMPLATE_MISMATCH_MAX = 3      // consecutive low-sim checks → kill (≈0.5s)
+    private var templateMismatchCount = 0
+
     /** Async embedding pipeline: compute embeddings on background thread, use results next frame. */
     private val embeddingExecutor = java.util.concurrent.Executors.newSingleThreadExecutor { r -> Thread(r, "EmbeddingAsync") }
     private var pendingEmbeddings: java.util.concurrent.Future<Map<Int, EmbeddingResult>>? = null
@@ -186,6 +199,7 @@ class ObjectTracker(
         vtUnconfirmedFrames = 0
         vtConfirmedFrames = 0
         vtFrameCounter = 0
+        templateMismatchCount = 0
         velocityEstimator.reset()
         pendingEmbeddings?.cancel(true)
         pendingEmbeddings = null
@@ -306,6 +320,26 @@ class ObjectTracker(
                         }
                     }
 
+                    // --- Template self-verification (R3) ---
+                    // Primary drift signal: compare current VT crop's embedding to the
+                    // lock gallery. Detector-independent, so it catches drift on small
+                    // or uniform objects the detector struggles with. Skipped on
+                    // detector-skip frames (no bitmap cost budget).
+                    if (!skipDetector &&
+                        reacquisition.hasEmbeddings &&
+                        vtFrameCounter % TEMPLATE_CHECK_INTERVAL == 0) {
+                        val curEmb = appearanceEmbedder.embedWithFallback(bitmap, rawBox)
+                        if (curEmb != null) {
+                            val sim = reacquisition.bestGallerySimilarity(curEmb)
+                            if (sim < TEMPLATE_SIM_THRESHOLD) {
+                                templateMismatchCount++
+                                android.util.Log.d("VisualTracker", "Template mismatch $templateMismatchCount/$TEMPLATE_MISMATCH_MAX (sim=${"%.3f".format(sim)})")
+                            } else {
+                                templateMismatchCount = 0
+                            }
+                        }
+                    }
+
                     // If too many frames without detector confirmation, tracker is drifting.
                     // Adaptive: fast-moving subjects get shorter tolerance (drift is more costly).
                     val adaptiveMaxUnconfirmed = when {
@@ -313,11 +347,15 @@ class ObjectTracker(
                         velocityEstimator.isHighVelocity() -> VT_ADAPTIVE_UNCONFIRMED_HIGH
                         else -> VT_MAX_UNCONFIRMED
                     }
-                    if (vtUnconfirmedFrames > adaptiveMaxUnconfirmed) {
-                        android.util.Log.w("VisualTracker", "DRIFT detected — $vtUnconfirmedFrames unconfirmed frames (max=$adaptiveMaxUnconfirmed, speed=${velocityEstimator.speed}), stopping")
+                    val templateDrift = templateMismatchCount >= TEMPLATE_MISMATCH_MAX
+                    val detectorDrift = vtUnconfirmedFrames > adaptiveMaxUnconfirmed
+                    if (templateDrift || detectorDrift) {
+                        val reason = if (templateDrift) "template mismatch ${templateMismatchCount}x" else "$vtUnconfirmedFrames unconfirmed frames (max=$adaptiveMaxUnconfirmed)"
+                        android.util.Log.w("VisualTracker", "DRIFT detected — $reason (conf=${vtResult.confidence}, speed=${velocityEstimator.speed}), stopping")
                         visualTracker.stop()
                         vtUnconfirmedFrames = 0
                         vtFrameCounter = 0
+                        templateMismatchCount = 0
                         // Fall through to detector path below
                     } else {
                         val lockedObj = TrackedObject(
@@ -356,6 +394,7 @@ class ObjectTracker(
                     // Visual tracker lost the object — fall through to detector
                     visualTracker.stop()
                     vtUnconfirmedFrames = 0
+                    templateMismatchCount = 0
                 }
             }
 
@@ -511,6 +550,7 @@ class ObjectTracker(
             // If re-acquired, re-initialize visual tracker
             if (wasSearching && lockedObject != null && reacquisition.framesLost == 0) {
                 visualTracker.init(bitmap, lockedObject.boundingBox)
+                templateMismatchCount = 0
             }
 
             // Save lastFrameBitmap before debug capture to avoid a third bitmap copy.


### PR DESCRIPTION
## Summary

Three structural fixes to tracking, bundled because they live in the same code path and were discovered iteratively:

1. **Template self-verification for VT drift** (#45) — replaces detector-dependent drift detection as the primary signal. Every 5 frames during VT tracking, embed the current crop and compare to the lock gallery. 3 consecutive similarities below 0.4 (~0.5s) triggers drift. Detector cross-check remains as a secondary safety net.

2. **Sync embedding fallback during rotation** (#53) — when the async embedding cache can't merge across frames (IoU < 0.3 due to position shift), synchronously embed the closest same-category candidate (~23ms one-time cost). Fixes 9-second reacquisition gaps where correct detections were hard-rejected because the embedding gate couldn't verify identity.

3. **Filter phantom detections before scoring** (#53) — `DetectionFilter` now runs before `ReacquisitionEngine.processFrame()` and `maxBoxArea` is lowered from 0.7 to 0.5. Prevents full-screen phantom detections (airplane/book at ~70% frame area from motion blur during rotation) from reaching the scoring pipeline.

## Research basis (#45)

The old VT drift detection had a structural flaw: it treated "detector found something elsewhere in the frame but not at VT position" as drift evidence, which is wrong — it's detector absence, not tracker drift. This caused false drift kills on small/uniform objects (yellow bowls, etc.) that EfficientDet can't reliably see.

Three attempts at fixing the detector cross-check (IoU > 0.05 ring, three-way signal classification with driftScore, DeepSORT-style max_age cap) all ran into parameter-tuning problems. Research on mature trackers (TLD PAMI 2012, Stark ICCV 2021, DaSiamRPN ECCV 2018, DeepSORT, ByteTrack, OC-SORT) consistently shows the primary drift signal should be the tracker's own self-assessment, not the detector. Template self-verification is the direct implementation of that principle.

## Device-tested behavior

- Flowerpot scenario: 11/12 reacquisitions within 2-22 frames, no false drift kills
- Template mismatch fired once correctly (sim=0.32) right before VT confidence also collapsed
- Remaining issues (e.g., 12-second gaps during 180° rotation) are detector coverage problems, not drift

## Files changed

| File | Changes |
|------|---------|
| `ObjectTracker.kt` | +84 lines: sync embedding fallback (~40 lines), template self-verification (~20 lines), filter-before-scoring (~4 lines), reset state in clear/reacquire paths |
| `DetectionFilter.kt` | `maxBoxArea` 0.7 → 0.5 |
| `CLAUDE.md` | Document all three changes + research rationale + new tunables + logcat tags |

## Test plan

- [x] 225+ unit tests pass
- [x] Device-tested manually across several sessions (bowl, flowerpot, toilet, laptop, mouse)
- [ ] On-device video replay tests — deferred pending code review
- [ ] Code review before merge

## Related

- Closes #45 (VT drift responsiveness — R3 from issue plan)
- Closes #53 (embedding delivery during rotation + phantom detections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)