### PR TITLE
Detector rotation + VT size/hysteresis + volume-up stealth

### DIFF
--- a/app/src/main/java/com/haptictrack/MainActivity.kt
+++ b/app/src/main/java/com/haptictrack/MainActivity.kt
@@ -29,6 +29,10 @@ class MainActivity : ComponentActivity() {
             viewModel.onVolumeDown()
             return true
         }
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+            viewModel.onVolumeUp()
+            return true
+        }
         return super.onKeyDown(keyCode, event)
     }
 }

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -208,9 +208,11 @@ class ObjectTracker(
     }
 
     /**
-     * Process a display-oriented bitmap from PreviewView.getBitmap().
-     * Unlike the ImageProxy path, the bitmap is already in screen orientation —
-     * no rotation is applied, and detector coordinates are used as-is (deviceRot=0).
+     * Process a display-oriented bitmap from the SurfaceTexture GL pipeline.
+     * The bitmap pixels are in display (phone-top) orientation. The detector
+     * reads [deviceRotationProvider] internally and rotates the bitmap to
+     * physical-upright before inference; VT and the rest of the pipeline
+     * continue operating in display-image coordinates.
      */
     fun processBitmap(bitmap: Bitmap) {
         processBitmapInternal(bitmap, deviceRotation = 0)
@@ -601,17 +603,27 @@ class ObjectTracker(
     }
 
     private fun runDetector(bitmap: Bitmap, frameWidth: Int, frameHeight: Int, deviceRot: Int): List<TrackedObject> {
-        val mpImage = BitmapImageBuilder(bitmap).build()
+        // EfficientDet fails on rotated scenes — pre-rotate the bitmap to
+        // physical-upright before inference when the phone is not in portrait.
+        // We read the physical device rotation from the provider (since the
+        // pipeline around us operates in display-image coords with deviceRot=0)
+        // and remap detector output back to display-image (screen) space.
+        val actualRot = deviceRotationProvider?.invoke() ?: 0
+        val upright = if (actualRot == 0) bitmap else rotateBitmap(bitmap, (-actualRot).toFloat())
+        val uprightW = upright.width
+        val uprightH = upright.height
+        val mpImage = BitmapImageBuilder(upright).build()
         val result: ObjectDetectorResult = detector.detect(mpImage)
 
-        return result.detections().map { detection ->
+        val detections = result.detections().map { detection ->
             val box = detection.boundingBox()
-            val normLeft = box.left / frameWidth.toFloat()
-            val normTop = box.top / frameHeight.toFloat()
-            val normRight = box.right / frameWidth.toFloat()
-            val normBottom = box.bottom / frameHeight.toFloat()
+            val normLeft = box.left / uprightW.toFloat()
+            val normTop = box.top / uprightH.toFloat()
+            val normRight = box.right / uprightW.toFloat()
+            val normBottom = box.bottom / uprightH.toFloat()
 
-            val screenBox = unmapRotation(normLeft, normTop, normRight, normBottom, deviceRot)
+            // actualRot used here (not the deviceRot parameter, which is 0)
+            val screenBox = unmapRotation(normLeft, normTop, normRight, normBottom, actualRot)
 
             TrackedObject(
                 id = -1,
@@ -620,6 +632,14 @@ class ObjectTracker(
                 confidence = detection.categories().firstOrNull()?.score() ?: 0f
             )
         }
+
+        if (upright !== bitmap) upright.recycle()
+        return detections
+    }
+
+    private fun rotateBitmap(bitmap: Bitmap, degrees: Float): Bitmap {
+        val matrix = android.graphics.Matrix().apply { postRotate(degrees) }
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
     }
 
     private fun captureDebugFrame(

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -265,7 +265,7 @@ class ObjectTracker(
                     val tracked = if (skipDetector) {
                         emptyList()
                     } else {
-                        val detections = runDetector(bitmap, frameWidth, frameHeight, deviceRotation)
+                        val detections = runDetector(bitmap)
                         frameTracker.assignIds(detections)
                     }
 
@@ -441,7 +441,7 @@ class ObjectTracker(
             }
 
             // --- Detector path: detection + re-acquisition ---
-            val detections = runDetector(bitmap, frameWidth, frameHeight, deviceRotation)
+            val detections = runDetector(bitmap)
             // Use velocity-shifted matching when tracking a fast-moving subject.
             // Shifts previous frame's boxes by velocity before IoU matching,
             // preventing ID churn from large displacements between frames.
@@ -640,12 +640,11 @@ class ObjectTracker(
         }
     }
 
-    private fun runDetector(bitmap: Bitmap, frameWidth: Int, frameHeight: Int, deviceRot: Int): List<TrackedObject> {
+    private fun runDetector(bitmap: Bitmap): List<TrackedObject> {
         // EfficientDet fails on rotated scenes — pre-rotate the bitmap to
         // physical-upright before inference when the phone is not in portrait.
-        // We read the physical device rotation from the provider (since the
-        // pipeline around us operates in display-image coords with deviceRot=0)
-        // and remap detector output back to display-image (screen) space.
+        // The rest of the pipeline operates in display-image coords; we remap
+        // detector output back to display-image (screen) space via unmapRotation.
         val actualRot = deviceRotationProvider?.invoke() ?: 0
         val upright = if (actualRot == 0) bitmap else rotateBitmap(bitmap, (-actualRot).toFloat())
         val uprightW = upright.width
@@ -660,7 +659,6 @@ class ObjectTracker(
             val normRight = box.right / uprightW.toFloat()
             val normBottom = box.bottom / uprightH.toFloat()
 
-            // actualRot used here (not the deviceRot parameter, which is 0)
             val screenBox = unmapRotation(normLeft, normTop, normRight, normBottom, actualRot)
 
             TrackedObject(

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -63,11 +63,26 @@ class ObjectTracker(
      * resembles the locked object → VT has drifted. Detector-independent,
      * so it catches drift even when the detector can't see the target
      * (small objects, uniform surfaces, label flicker).
+     *
+     * Asymmetric thresholds (hysteresis): increment the counter when sim falls
+     * below TEMPLATE_SIM_LOW, reset only when sim rises above TEMPLATE_SIM_OK.
+     * This prevents oscillation around a single threshold from masking drift.
      */
     private val TEMPLATE_CHECK_INTERVAL = 5    // embed VT crop every N frames
-    private val TEMPLATE_SIM_THRESHOLD = 0.4f  // below this = drift suspicion
+    private val TEMPLATE_SIM_LOW = 0.4f        // below this = drift suspicion (increment)
+    private val TEMPLATE_SIM_OK = 0.5f         // above this = safe (reset counter)
     private val TEMPLATE_MISMATCH_MAX = 3      // consecutive low-sim checks → kill (≈0.5s)
     private var templateMismatchCount = 0
+
+    /**
+     * VT box size sanity check: the tracker's output box shouldn't grow
+     * dramatically relative to the box it was initialized with. Objects don't
+     * physically grow 5x in a fraction of a second — if VT is producing a
+     * much larger box, it has latched onto a larger texture pattern (e.g.
+     * the whole screen) instead of the locked object.
+     */
+    private val VT_BOX_AREA_MAX_RATIO = 5f
+    private var vtLockedBoxArea = 0f  // area of VT's init box (normalized 0..1)
 
     /** Async embedding pipeline: compute embeddings on background thread, use results next frame. */
     private val embeddingExecutor = java.util.concurrent.Executors.newSingleThreadExecutor { r -> Thread(r, "EmbeddingAsync") }
@@ -160,6 +175,7 @@ class ObjectTracker(
             reacquisition.lock(trackingId, boundingBox, enrichedLabel, augResult.embeddings, colorHist, personAttrs,
                 cocoLabel = label, reIdEmbedding = reIdEmb, faceEmbedding = faceEmb)
             visualTracker.init(bmp, boundingBox)
+            vtLockedBoxArea = boundingBox.width() * boundingBox.height()
 
             debugCapture.startSession(enrichedLabel, trackingId)
             val attrStr = personAttrs?.summary() ?: "n/a"
@@ -200,6 +216,7 @@ class ObjectTracker(
         vtConfirmedFrames = 0
         vtFrameCounter = 0
         templateMismatchCount = 0
+        vtLockedBoxArea = 0f
         velocityEstimator.reset()
         pendingEmbeddings?.cancel(true)
         pendingEmbeddings = null
@@ -330,20 +347,34 @@ class ObjectTracker(
                     //
                     // Effective rate is every ~5 frames normally, ~10 frames when VT
                     // frame skipping is active (skipDetector=true on alternate frames).
+                    //
+                    // Hysteresis: increment when sim < TEMPLATE_SIM_LOW, reset only
+                    // when sim > TEMPLATE_SIM_OK. Values in between (the dead zone)
+                    // leave the counter unchanged so marginal oscillation can't mask
+                    // real drift.
                     if (!skipDetector &&
                         reacquisition.hasEmbeddings &&
                         vtFrameCounter % TEMPLATE_CHECK_INTERVAL == 0) {
                         val curEmb = appearanceEmbedder.embedWithFallback(bitmap, rawBox)
                         if (curEmb != null) {
                             val sim = reacquisition.bestGallerySimilarity(curEmb)
-                            if (sim < TEMPLATE_SIM_THRESHOLD) {
-                                templateMismatchCount++
-                                android.util.Log.d("VisualTracker", "Template mismatch $templateMismatchCount/$TEMPLATE_MISMATCH_MAX (sim=${"%.3f".format(sim)})")
-                            } else {
-                                templateMismatchCount = 0
+                            when {
+                                sim < TEMPLATE_SIM_LOW -> {
+                                    templateMismatchCount++
+                                    android.util.Log.d("VisualTracker", "Template mismatch $templateMismatchCount/$TEMPLATE_MISMATCH_MAX (sim=${"%.3f".format(sim)})")
+                                }
+                                sim > TEMPLATE_SIM_OK -> templateMismatchCount = 0
+                                else -> { /* dead zone — hold the counter */ }
                             }
                         }
                     }
+
+                    // VT box size sanity: if the tracker's output is much larger than
+                    // what we initialized it with, VT has latched onto background
+                    // texture (classic "expands to whole screen" drift).
+                    val vtBoxArea = vtBox.width() * vtBox.height()
+                    val sizeDrift = vtLockedBoxArea > 0f &&
+                        vtBoxArea > vtLockedBoxArea * VT_BOX_AREA_MAX_RATIO
 
                     // If too many frames without detector confirmation, tracker is drifting.
                     // Adaptive: fast-moving subjects get shorter tolerance (drift is more costly).
@@ -354,13 +385,18 @@ class ObjectTracker(
                     }
                     val templateDrift = templateMismatchCount >= TEMPLATE_MISMATCH_MAX
                     val detectorDrift = vtUnconfirmedFrames > adaptiveMaxUnconfirmed
-                    if (templateDrift || detectorDrift) {
-                        val reason = if (templateDrift) "template mismatch ${templateMismatchCount}x" else "$vtUnconfirmedFrames unconfirmed frames (max=$adaptiveMaxUnconfirmed)"
+                    if (sizeDrift || templateDrift || detectorDrift) {
+                        val reason = when {
+                            sizeDrift -> "box expanded ${"%.1fx".format(vtBoxArea / vtLockedBoxArea)} (area=${"%.3f".format(vtBoxArea)})"
+                            templateDrift -> "template mismatch ${templateMismatchCount}x"
+                            else -> "$vtUnconfirmedFrames unconfirmed frames (max=$adaptiveMaxUnconfirmed)"
+                        }
                         android.util.Log.w("VisualTracker", "DRIFT detected — $reason (conf=${vtResult.confidence}, speed=${velocityEstimator.speed}), stopping")
                         visualTracker.stop()
                         vtUnconfirmedFrames = 0
                         vtFrameCounter = 0
                         templateMismatchCount = 0
+                        vtLockedBoxArea = 0f
                         // Fall through to detector path below
                     } else {
                         val lockedObj = TrackedObject(
@@ -400,6 +436,7 @@ class ObjectTracker(
                     visualTracker.stop()
                     vtUnconfirmedFrames = 0
                     templateMismatchCount = 0
+                    vtLockedBoxArea = 0f
                 }
             }
 
@@ -555,6 +592,7 @@ class ObjectTracker(
             // If re-acquired, re-initialize visual tracker
             if (wasSearching && lockedObject != null && reacquisition.framesLost == 0) {
                 visualTracker.init(bitmap, lockedObject.boundingBox)
+                vtLockedBoxArea = lockedObject.boundingBox.width() * lockedObject.boundingBox.height()
                 templateMismatchCount = 0
             }
 

--- a/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
@@ -251,6 +251,11 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                 modifier = Modifier
                     .fillMaxSize()
                     .pointerInteropFilter { event ->
+                        // In stealth mode, swallow all touches — the volume-up key is
+                        // the only way in/out. Prevents accidental taps from locking or
+                        // exiting stealth.
+                        if (uiState.stealthMode) return@pointerInteropFilter true
+
                         scaleDetector.onTouchEvent(event)
 
                         if (scaleDetector.isInProgress) {
@@ -318,8 +323,8 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
             }
 
             // In stealth mode, show nothing — completely black screen.
-            // Volume-down is the only control (lock → record → stop+clear).
-            // Tap anywhere to exit stealth.
+            // Volume-up toggles stealth. Volume-down runs the lock → record →
+            // stop+clear cycle. Touches are swallowed by the preview handler.
             if (!uiState.stealthMode) {
                 // Bounding box / contour overlay
                 TrackingOverlay(
@@ -406,34 +411,7 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                     }
                 }
 
-                // Stealth mode toggle
-                Button(
-                    onClick = { viewModel.toggleStealthMode() },
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(top = if (uiState.status != TrackingStatus.IDLE) 64.dp else 112.dp, start = 16.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.Black.copy(alpha = 0.5f))
-                ) {
-                    Text("STEALTH", color = Color.White, fontSize = 12.sp)
-                }
-            } else {
-                // Stealth mode: tap anywhere to exit
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .pointerInput(Unit) {
-                            awaitPointerEventScope {
-                                while (true) {
-                                    val event = awaitPointerEvent()
-                                    if (event.changes.any { it.pressed }) {
-                                        event.changes.forEach { it.consume() }
-                                        viewModel.toggleStealthMode()
-                                        break
-                                    }
-                                }
-                            }
-                        }
-                )
+                // Stealth mode is toggled by volume-up (see MainActivity) — no button.
             }
         }
     } else {

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -259,6 +259,11 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         // Stealth is purely a UI overlay change.
     }
 
+    /** Volume-up: toggle stealth mode. Entry/exit point for hands-free stealth. */
+    fun onVolumeUp() {
+        toggleStealthMode()
+    }
+
     fun switchCamera() {
         clearTracking()
         cameraManager.switchCamera()


### PR DESCRIPTION
Stacked on top of #55. Three independent improvements:

## 1. Detector rotation fix

EfficientDet fails on rotated scenes — when the phone is physically rotated (deviceRotation != 0), the bitmap from the SurfaceTexture GL pipeline contains a rotated scene and the detector produces 0 candidates despite the target being visible.

`runDetector` now reads the physical rotation from `deviceRotationProvider`, pre-rotates the bitmap to physical-upright before inference, and uses `unmapRotation` to convert output boxes back to display-space for the rest of the pipeline.

Fixes 12-second reacquisition gaps during rotation that were observed in the flowerpot session.

## 2. VT drift: box size check + template hysteresis

Two additional drift signals to catch the "VT expands to whole screen" failure mode that was slipping past the existing signals:

- **Box size sanity**: if VT's output box area exceeds 5x the area of the box it was initialized with, kill immediately. Objects don't grow 5x in a fraction of a second — this means VT latched onto background texture.
- **Template mismatch hysteresis**: replaces single 0.4 threshold with asymmetric thresholds. Increment counter below 0.4, reset only above 0.5. The 0.4–0.5 dead zone holds the counter so oscillation at the boundary can't mask real drift.

Both signals verified on device: fire within 1–2s of a bad reacquire (previously ~10s via the detector cross-check safety net).

## 3. Stealth mode UX: volume-up control, touch blocked

- Volume-up now toggles stealth mode (mirrors the volume-down lock/record cycle). Volume-down behavior unchanged.
- Removed the on-screen STEALTH button.
- Swallow all touches on the preview while in stealth mode. Volume-up is the only way in/out — prevents accidental taps from exiting stealth or locking on objects.

## Test plan

- [x] 225+ unit tests pass
- [x] Device-tested manually across multiple sessions (flowerpot, dog, mouse, tv)
- [x] Size-drift signal fired correctly on 2 real "expanded to whole screen" events
- [x] Template hysteresis resets only on clear recovery (sim > 0.5)
- [x] Stealth mode: volume-up toggles, touches blocked while in stealth

## Related

- Builds on #55
- Closes remaining sub-items of #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)