### PR TITLE
VT skip interval: widen to 3 when long-stable (#62 A1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,8 +348,8 @@ Three-stage cycle on volume-down: idle → lock on center object, tracking → s
 ### GPU delegate for all models (decided 2026-04-18, updated 2026-04-19)
 All 9 ML models run on GPU. EfficientDet-Lite2 switched from INT8 (CPU) to FP16 (GPU) — downloaded from MediaPipe model zoo, same structure (448x448, 90 classes), fewer spurious detections. TFLite models use `createGpuInterpreter()` which returns `GpuInterpreter` (interpreter + delegate pair) with `Throwable` catch for CPU fallback. MediaPipe models use `Delegate.GPU` via `BaseOptions.setDelegate()`. InteractiveSegmenter GPU has a crop size limit — Adreno 740 returns empty masks above ~100K pixels, so large crops are downscaled to ~300x300 before segmenting (MAX_SEGMENT_PIXELS = 90000).
 
-### Adaptive frame skipping during visual tracking (decided 2026-04-18)
-When VitTracker is confident (>0.6) and has 5+ confirmed frames with 0 unconfirmed, skip the EfficientDet detector every other frame. VT alone runs at ~5ms vs ~35ms for detector. Still runs detector every 2nd frame for drift detection. Saves ~50% detector compute while locked. Resets on drift, lock clear, or VT stop.
+### Adaptive frame skipping during visual tracking (decided 2026-04-18, widened 2026-04-24)
+Two-tier skip interval. **Base regime** (confidence >0.6, confirmed ≥5, 0 unconfirmed): run detector every 2nd frame (~50% skipped). **Stable regime** (confidence >0.7, confirmed ≥10): run detector every 3rd frame (~67% skipped). VT alone runs at ~5ms vs ~35ms for detector. Template self-verification (#45, every 5 frames) is the primary drift signal now, so the detector cadence can be a slower safety net once VT has been stable for a while. Resets on drift, lock clear, or VT stop.
 
 ## Logging
 
@@ -490,8 +490,11 @@ All in constructor defaults — no settings UI yet:
 | `targetFrameOccupancy` | ZoomController | 0.15 | Target subject size as fraction of frame |
 | `zoomSpeed` | ZoomController | 0.05 | Zoom change per frame |
 | `scoreThreshold` | ObjectTracker (MediaPipe) | 0.5 | MediaPipe detector confidence cutoff |
-| `VT_SKIP_INTERVAL` | ObjectTracker | 2 | Run detector every Nth frame when VT is skipping |
+| `VT_SKIP_INTERVAL_BASE` | ObjectTracker | 2 | Default skip interval (50% detector frames) |
+| `VT_SKIP_INTERVAL_STABLE` | ObjectTracker | 3 | Widened interval when VT is long-stable (33% detector frames) |
 | `VT_SKIP_MIN_CONFIRMED` | ObjectTracker | 5 | Min VT confirmations before frame skipping kicks in |
+| `VT_SKIP_STABLE_CONFIRMED` | ObjectTracker | 10 | Confirmations required to switch to the stable skip interval |
+| `VT_SKIP_STABLE_CONFIDENCE` | ObjectTracker | 0.7 | VT confidence required to switch to the stable skip interval |
 
 ## What's Built vs. What's Not
 

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -55,8 +55,11 @@ class ObjectTracker(
 
     /** Skip detector every other frame when VT is confident and recently confirmed. */
     private var vtFrameCounter = 0
-    private val VT_SKIP_INTERVAL = 2  // run detector every Nth frame when skipping
-    private val VT_SKIP_MIN_CONFIRMED = 5  // need this many confirmations before skipping
+    private val VT_SKIP_INTERVAL_BASE = 2  // default: run detector every 2nd frame (50% skip)
+    private val VT_SKIP_INTERVAL_STABLE = 3  // highly confident + long-stable: every 3rd frame (67% skip)
+    private val VT_SKIP_MIN_CONFIRMED = 5  // need this many confirmations before skipping at all
+    private val VT_SKIP_STABLE_CONFIRMED = 10  // confirmations required for wider skip interval
+    private val VT_SKIP_STABLE_CONFIDENCE = 0.7f  // VT confidence required for wider skip interval
 
     /** Tracks object velocity for adaptive drift detection and position prediction. */
     private val velocityEstimator = VelocityEstimator()
@@ -267,11 +270,18 @@ class ObjectTracker(
 
                     // Skip detector when VT is confident and recently confirmed.
                     // Saves ~35ms per skipped frame. Still run every Nth frame for drift detection.
+                    // Widen the interval once VT has been confirmed for a long stretch at high
+                    // confidence — the detector's role at that point is a slow safety net,
+                    // template self-verification (every 5 frames) is the primary drift signal.
                     vtFrameCounter++
                     val canSkip = vtConfirmedFrames >= VT_SKIP_MIN_CONFIRMED &&
                         vtUnconfirmedFrames == 0 &&
                         vtResult.confidence > 0.6f
-                    val skipDetector = canSkip && (vtFrameCounter % VT_SKIP_INTERVAL != 0)
+                    val skipInterval = if (
+                        vtConfirmedFrames >= VT_SKIP_STABLE_CONFIRMED &&
+                        vtResult.confidence > VT_SKIP_STABLE_CONFIDENCE
+                    ) VT_SKIP_INTERVAL_STABLE else VT_SKIP_INTERVAL_BASE
+                    val skipDetector = canSkip && (vtFrameCounter % skipInterval != 0)
 
                     val tracked = if (skipDetector) {
                         emptyList()


### PR DESCRIPTION
## Summary
- Two-tier skip interval during visual tracking. **Base** (confidence >0.6, confirmed ≥5) keeps the existing every-2nd-frame detector cadence. **Stable** (confidence >0.7, confirmed ≥10) runs detector every 3rd frame (~67% skipped).
- Template self-verification (#45, every 5 frames) is the primary drift signal now, so detector cadence can be a slower safety net once VT has been stable for a while.
- First of three tier-1 follow-ups from #62.

## Measured impact (Snapdragon 870 / live camera, cup session)

| Phase | Master baseline | This branch |
|---|---|---|
| Pre-lock idle | ~30fps | ~30fps |
| Lock burst | 28ms spike | 28ms spike (unchanged — D1) |
| Active steady tracking | 41-45ms / 22-24fps | **39-42ms / 24-25fps** |
| Search / LOST spikes | 50-70ms | 50-70ms (unchanged — B2) |

~2-4ms saved per frame in cruise, ~1-2fps bump. Below the theoretical ~6ms because the stable gate isn't always satisfied during real tracking — VT wobbles in and out of stable as the subject moves. Correct behavior.

Session log confirms tracking quality unaffected: cup session reacquired 3× cleanly.

## Why this is safe
- The base regime (interval=2) is unchanged for the VT warm-up phase.
- Template self-verification runs every 5 frames regardless of detector cadence; it's independent of this change.
- Template mismatch / unconfirmed counters still trip drift detection at the same thresholds.
- Resets on drift, lock clear, or VT stop — exactly as before.

## Test plan
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Build + deploy to device
- [x] Lock on a stable cup, observe `STFrameReader` log — active steady at 39-42ms, 24-25fps
- [x] Confirm reacquires still fire cleanly (3× in the test session)
- [ ] Video replay suite — run before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)