### PR TITLE
lockOnObject: move ML burst off processing thread (#62 D1)

### DIFF
--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -126,6 +126,34 @@ class ObjectTracker(
     private val SYNC_EMBED_CACHE_FRAMES = 30  // ~1-2s at typical search fps; IoU is the real staleness guard
     private val SYNC_EMBED_CACHE_IOU = 0.5f  // box must overlap this much with cached box
 
+    /**
+     * Off-thread lock-on. The full lock burst (5 augmented embeddings + segmenter
+     * + person classifier + re-id + face + scene negatives) is ~150-250ms of GPU
+     * work that used to run on the processing thread under lastFrameLock, blocking
+     * frame processing for the full duration. Now we snapshot a bitmap, release
+     * the lock immediately, and run the ML on a dedicated thread; the processing
+     * thread picks the result up at the next frame boundary.
+     */
+    private val lockExecutor = java.util.concurrent.Executors.newSingleThreadExecutor { r -> Thread(r, "LockOnObject") }
+    private var pendingLockFuture: java.util.concurrent.Future<*>? = null
+    private val pendingLockResult = java.util.concurrent.atomic.AtomicReference<LockResult?>()
+
+    /** Result of off-thread lock ML; applied on the processing thread. */
+    private data class LockResult(
+        val trackingId: Int,
+        val boundingBox: RectF,
+        val label: String?,
+        val gallery: List<FloatArray>,
+        val colorHist: FloatArray?,
+        val personAttrs: PersonAttributes?,
+        val reIdEmb: FloatArray?,
+        val faceEmb: FloatArray?,
+        val sceneNegatives: List<FloatArray>,
+        val deviceRotation: Int,
+        /** Snapshot bitmap; ownership transfers to whoever applies/cancels this result. */
+        val snapshotBmp: Bitmap
+    )
+
     /** Callback: (displayObjects, lockedObject, imageWidth, imageHeight, contour) */
     var onDetectionResult: ((List<TrackedObject>, TrackedObject?, Int, Int, List<PointF>) -> Unit)? = null
 
@@ -175,54 +203,101 @@ class ObjectTracker(
      * the visual embedding for identity-aware re-acquisition.
      */
     fun lockOnObject(trackingId: Int, boundingBox: RectF, label: String?) {
+        // Snapshot the latest frame + detections atomically, then release the
+        // lastFrameLock immediately so the processing thread can keep producing
+        // frames during the lock burst.
+        val snapshotBmp: Bitmap
+        val snapshotDevRot: Int
+        val snapshotDetections: List<TrackedObject>
         synchronized(lastFrameLock) {
-            val bmp = lastFrameBitmap ?: run {
+            val src = lastFrameBitmap ?: run {
                 reacquisition.lock(trackingId, boundingBox, label, emptyList())
                 return
             }
+            snapshotBmp = src.copy(src.config ?: Bitmap.Config.ARGB_8888, false)
+            snapshotDevRot = lastFrameDeviceRotation
+            snapshotDetections = lastDetections.toList()
+        }
 
-            val augResult = appearanceEmbedder.embedWithAugmentations(bmp, boundingBox)
-            // Compute color histogram on the masked crop (single segmentation pass)
-            val colorHist = if (augResult.maskedCrop != null) {
-                val fullBox = RectF(0f, 0f, 1f, 1f) // crop is already the object
-                computeColorHistogram(augResult.maskedCrop, fullBox).also { augResult.maskedCrop.recycle() }
-            } else computeColorHistogram(bmp, boundingBox)
-            // Classify person attributes at lock time (use original COCO label for "person" check)
-            val personAttrs = personClassifier.classify(bmp, boundingBox, label)
-            // Person re-ID + face embeddings (only for person labels)
-            val isPerson = label == "person"
-            val reIdEmb = if (isPerson) personReId.embed(bmp, boundingBox) else null
-            val faceEmb = if (isPerson) faceEmbedder.embedFace(bmp, boundingBox) else null
-            reacquisition.lock(trackingId, boundingBox, label, augResult.embeddings, colorHist, personAttrs,
-                cocoLabel = label, reIdEmbedding = reIdEmb, faceEmbedding = faceEmb)
-            visualTracker.init(bmp, boundingBox)
-            vtLockedBoxArea = boundingBox.width() * boundingBox.height()
+        // Cancel any in-flight prior lock and discard its result if not yet applied.
+        pendingLockFuture?.cancel(true)
+        pendingLockResult.getAndSet(null)?.snapshotBmp?.recycle()
 
-            debugCapture.startSession(label, trackingId)
-            val attrStr = personAttrs?.summary() ?: "n/a"
-            debugCapture.log("LOCK id=$trackingId label=$label box=${boundingBox} gallery=${augResult.embeddings.size} colorHist=${colorHist != null} attrs=\"$attrStr\"")
+        pendingLockFuture = lockExecutor.submit {
+            try {
+                val augResult = appearanceEmbedder.embedWithAugmentations(snapshotBmp, boundingBox)
+                val colorHist = if (augResult.maskedCrop != null) {
+                    val fullBox = RectF(0f, 0f, 1f, 1f)
+                    computeColorHistogram(augResult.maskedCrop, fullBox).also { augResult.maskedCrop.recycle() }
+                } else computeColorHistogram(snapshotBmp, boundingBox)
+                val personAttrs = personClassifier.classify(snapshotBmp, boundingBox, label)
+                val isPerson = label == "person"
+                val reIdEmb = if (isPerson) personReId.embed(snapshotBmp, boundingBox) else null
+                val faceEmb = if (isPerson) faceEmbedder.embedFace(snapshotBmp, boundingBox) else null
 
-            // Start scenario recording for replay testing
+                // Scene negatives: embed every other detection visible at lock time.
+                // boundingBox is screen-space; remap to rotated-image space to crop.
+                val sceneNegs = mutableListOf<FloatArray>()
+                for (det in snapshotDetections) {
+                    if (det.id == trackingId) continue
+                    val rotBox = mapToRotated(det.boundingBox.left, det.boundingBox.top,
+                        det.boundingBox.right, det.boundingBox.bottom, snapshotDevRot)
+                    val negEmb = appearanceEmbedder.embed(snapshotBmp, rotBox)
+                    if (negEmb != null) sceneNegs.add(negEmb)
+                }
+
+                val result = LockResult(
+                    trackingId = trackingId,
+                    boundingBox = boundingBox,
+                    label = label,
+                    gallery = augResult.embeddings,
+                    colorHist = colorHist,
+                    personAttrs = personAttrs,
+                    reIdEmb = reIdEmb,
+                    faceEmb = faceEmb,
+                    sceneNegatives = sceneNegs,
+                    deviceRotation = snapshotDevRot,
+                    snapshotBmp = snapshotBmp
+                )
+                // Hand off; if a previous result is still pending, recycle its bitmap.
+                pendingLockResult.getAndSet(result)?.snapshotBmp?.recycle()
+            } catch (t: Throwable) {
+                android.util.Log.e("ObjectTracker", "Lock ML failed: ${t.message}", t)
+                snapshotBmp.recycle()
+            }
+        }
+    }
+
+    /**
+     * Apply a completed off-thread lock result on the processing thread. Called at
+     * the start of [processBitmapInternal] so all state mutation happens on the
+     * single thread that reads it. Recycles the snapshot bitmap once consumed.
+     */
+    private fun applyPendingLockIfAny() {
+        val result = pendingLockResult.getAndSet(null) ?: return
+        try {
+            reacquisition.lock(result.trackingId, result.boundingBox, result.label,
+                result.gallery, result.colorHist, result.personAttrs,
+                cocoLabel = result.label, reIdEmbedding = result.reIdEmb, faceEmbedding = result.faceEmb)
+            visualTracker.init(result.snapshotBmp, result.boundingBox)
+            vtLockedBoxArea = result.boundingBox.width() * result.boundingBox.height()
+
+            for (neg in result.sceneNegatives) reacquisition.addSceneNegative(neg)
+
+            debugCapture.startSession(result.label, result.trackingId)
+            val attrStr = result.personAttrs?.summary() ?: "n/a"
+            debugCapture.log("LOCK id=${result.trackingId} label=${result.label} box=${result.boundingBox} gallery=${result.gallery.size} colorHist=${result.colorHist != null} attrs=\"$attrStr\"")
+
             debugCapture.sessionDir?.let { dir ->
-                scenarioRecorder.start(dir, trackingId, label, label,
-                    boundingBox, augResult.embeddings, colorHist, personAttrs)
+                scenarioRecorder.start(dir, result.trackingId, result.label, result.label,
+                    result.boundingBox, result.gallery, result.colorHist, result.personAttrs)
             }
 
-            // Collect scene negatives from other objects visible at lock time.
-            // lastDetections has screen-space boxes but bmp is the rotated bitmap,
-            // so convert back to rotated-image space before cropping.
-            val lockDevRot = lastFrameDeviceRotation
-            for (det in lastDetections) {
-                if (det.id == trackingId) continue
-                val rotBox = mapToRotated(det.boundingBox.left, det.boundingBox.top,
-                    det.boundingBox.right, det.boundingBox.bottom, lockDevRot)
-                val negEmb = appearanceEmbedder.embed(bmp, rotBox)
-                if (negEmb != null) reacquisition.addSceneNegative(negEmb)
-            }
-
-            val locked = TrackedObject(trackingId, boundingBox, label)
-            debugCapture.capture(DebugEvent.LOCK, bmp, listOf(locked), lockedObject = locked,
-                extraInfo = "id=$trackingId label=$label gallery=${augResult.embeddings.size}")
+            val locked = TrackedObject(result.trackingId, result.boundingBox, result.label)
+            debugCapture.capture(DebugEvent.LOCK, result.snapshotBmp, listOf(locked), lockedObject = locked,
+                extraInfo = "id=${result.trackingId} label=${result.label} gallery=${result.gallery.size}")
+        } finally {
+            result.snapshotBmp.recycle()
         }
     }
 
@@ -241,6 +316,9 @@ class ObjectTracker(
         velocityEstimator.reset()
         pendingEmbeddings?.cancel(true)
         pendingEmbeddings = null
+        pendingLockFuture?.cancel(true)
+        pendingLockFuture = null
+        pendingLockResult.getAndSet(null)?.snapshotBmp?.recycle()
         recentSyncEmbeds.clear()
         cachedContour = emptyList()
         contourFrameCount = 0
@@ -258,6 +336,9 @@ class ObjectTracker(
     }
 
     private fun processBitmapInternal(bitmap: Bitmap, deviceRotation: Int) {
+        // Apply any off-thread lock that completed since the last frame.
+        applyPendingLockIfAny()
+
         val frameWidth = bitmap.width
         val frameHeight = bitmap.height
 
@@ -901,6 +982,8 @@ class ObjectTracker(
         scenarioRecorder.stop()
         debugCapture.shutdown()
         embeddingExecutor.shutdownNow()
+        lockExecutor.shutdownNow()
+        pendingLockResult.getAndSet(null)?.snapshotBmp?.recycle()
         detector.close()
         faceEmbedder.close()
         personReId.close()


### PR DESCRIPTION
## Summary
- Move the ~150-250ms lock-time ML burst (5 augmented embeddings + segmenter + person classifier + OSNet re-id + MobileFaceNet + scene negatives) off the processing thread.
- Snapshot bitmap + state under \`lastFrameLock\`, release immediately, run ML on a dedicated \`lockExecutor\` thread.
- Processing thread picks up the completed \`LockResult\` via \`AtomicReference\` and applies state mutations on the next frame.
- Stacked on #64 (B2). Merge #63 → #64 → this in order.

## Why
Pre-D1, \`lockOnObject\` held \`lastFrameLock\` for the full ~150-250ms ML burst, blocking the processing thread (which also acquires \`lastFrameLock\` to update \`lastFrameBitmap\`). Result: viewfinder froze on tap, and \`BitmapRing\` pool overflow allocations happened during the window because the processing thread couldn't return frames to the pool.

## What stays on the processing thread
- VT init (~30-50ms) — kept here to avoid touching \`VisualTracker\`'s thread-safety. If we want to move this off too, we'd need synchronization in \`VisualTracker.init/update/stop\`. Worth a follow-up if VT init shows up as a bottleneck.
- All state mutations (\`reacquisition.lock\`, debug capture, scenario recorder, scene-negative gallery additions). These are serialized through \`applyPendingLockIfAny()\` which runs on the processing thread.

## Bitmap ownership
- Snapshot bitmap is owned by the in-flight \`LockResult\`.
- A new lock cancels the prior future and recycles its (yet-unapplied) snapshot.
- \`clearLock\` cancels and recycles.
- \`shutdown\` shuts down the executor and recycles any pending bitmap.

## Test plan
- [x] Unit tests pass
- [x] Build + deploy to device
- [x] Subjective: lock latency feels negligible — no viewfinder freeze on tap
- [x] Tracking quality preserved across multiple sessions:
  - Cup session: 7+ reacquires (sim 0.60-0.96)
  - Bowl session: bowl→cup label-flicker override fired (sim=0.96)
  - Chair session: 5 reacquires (16, 16, 17, 97, 1 frame latencies)
- [x] Gallery growth + scene negatives unchanged
- [ ] Edge case: clear during lock window — code path is correct (cancel + recycle), worth a manual repro

## What remains
- A3 (parallelize detector + embedder), B1 (sync embed batching), C1-C3 (GLES3 unlocks) — all in #62 tier 2/3.
- FTFTracker stability (#65) — orthogonal but compounds with everything in #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)