### PR TITLE
Identity: gate persons on OSNet, fix self-poisoning negatives (#67)

### DIFF
--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -119,6 +119,8 @@ class ObjectTracker(
     private data class SyncEmbedEntry(
         val embedding: FloatArray,
         val colorHistogram: FloatArray?,
+        val reIdEmbedding: FloatArray? = null,
+        val faceEmbedding: FloatArray? = null,
         val cachedBox: RectF,
         val framesLost: Int
     )
@@ -687,8 +689,8 @@ class ObjectTracker(
                         val reusable = cached != null &&
                             computeIou(best.boundingBox, cached.cachedBox) > SYNC_EMBED_CACHE_IOU
 
-                        val (embedding, hist) = if (reusable) {
-                            cached!!.embedding to cached.colorHistogram
+                        val syncEntry: SyncEmbedEntry? = if (reusable) {
+                            cached
                         } else {
                             // Compute embedding synchronously (raw crop fallback, ~8-23ms)
                             val embResult = appearanceEmbedder.embedAndCrop(bitmap, best.boundingBox, fallback = true)
@@ -697,22 +699,35 @@ class ObjectTracker(
                                 computeColorHistogram(embResult.maskedCrop, fullBox).also { embResult.maskedCrop.recycle() }
                             } else computeColorHistogram(bitmap, best.boundingBox)
                             if (embResult.embedding != null) {
-                                android.util.Log.d("EmbedSync", "Sync embedding for id=${best.id} label=${best.label}")
-                                recentSyncEmbeds[best.id] = SyncEmbedEntry(
+                                // Person candidates also need OSNet (and face when locked
+                                // has a face) so the new OSNet-gated path (#67) can fire
+                                // on freshly-embedded candidates without waiting for async.
+                                val isPersonCandidate = lockedIsPerson && best.label == "person"
+                                val reIdEmb = if (isPersonCandidate) personReId.embed(bitmap, best.boundingBox) else null
+                                val faceEmb = if (isPersonCandidate && reacquisition.lockedFaceEmbedding != null) {
+                                    faceEmbedder.embedFace(bitmap, best.boundingBox)
+                                } else null
+                                android.util.Log.d("EmbedSync", "Sync embedding for id=${best.id} label=${best.label} reId=${reIdEmb != null} face=${faceEmb != null}")
+                                val entry = SyncEmbedEntry(
                                     embedding = embResult.embedding,
                                     colorHistogram = computedHist,
+                                    reIdEmbedding = reIdEmb,
+                                    faceEmbedding = faceEmb,
                                     cachedBox = RectF(best.boundingBox),
                                     framesLost = currFramesLost
                                 )
-                            }
-                            embResult.embedding to computedHist
+                                recentSyncEmbeds[best.id] = entry
+                                entry
+                            } else null
                         }
 
-                        if (embedding != null) {
+                        if (syncEntry != null) {
                             merged.map { obj ->
                                 if (obj.id == best.id) obj.copy(
-                                    embedding = embedding,
-                                    colorHistogram = hist
+                                    embedding = syncEntry.embedding,
+                                    colorHistogram = syncEntry.colorHistogram,
+                                    reIdEmbedding = syncEntry.reIdEmbedding ?: obj.reIdEmbedding,
+                                    faceEmbedding = syncEntry.faceEmbedding ?: obj.faceEmbedding
                                 ) else obj
                             }
                         } else merged
@@ -955,17 +970,15 @@ class ObjectTracker(
             } else computeColorHistogram(bitmap, obj.boundingBox)
             results[obj.id] = EmbeddingResult(embedding = embResult.embedding, colorHistogram = hist, cachedBox = RectF(obj.boundingBox))
         }
-        // Second pass: classify top-2 person candidates
-        val personCandidates = detections
+        // Second pass: classify all person candidates. Previously this was filtered
+        // to top-2 by MobileNetV3 sim, which silently dropped the right person from
+        // OSNet computation when MobileNetV3 ranked the wrong candidate higher
+        // (#67). With the OSNet gate, every person candidate needs its OSNet
+        // embedding so the engine can decide on identity.
+        val personIds = detections
             .filter { it.label == "person" && results[it.id]?.embedding != null }
-            .sortedByDescending {
-                val emb = results[it.id]?.embedding
-                if (emb != null) reacquisition.bestGallerySimilarity(emb) else 0f
-            }
-            .take(2)
             .map { it.id }
-            .toSet()
-        for (id in personCandidates) {
+        for (id in personIds) {
             val obj = detections.find { it.id == id } ?: continue
             val attrs = personClassifier.classify(bitmap, obj.boundingBox, obj.label)
             val reIdEmb = personReId.embed(bitmap, obj.boundingBox)

--- a/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
@@ -44,6 +44,11 @@ class ReacquisitionEngine(
          *  If the primary embedder says the candidate is a different object (sim < this),
          *  no amount of re-ID, attributes, or color can rescue it. */
         const val MIN_EMBEDDING_SIMILARITY = 0.15f
+        /** Floor for OSNet (person re-ID) cosine similarity when gating person candidates.
+         *  OSNet on Market-1501 produces same-person sim typically in [0.5, 0.85] and
+         *  different-person sim in [0.2, 0.4]. 0.45 sits in the gap. Tuned from a live
+         *  capture where same-person reId hit 0.836 while MobileNetV3 sim was 0.558. */
+        const val PERSON_REID_FLOOR = 0.45f
         /** Maximum embeddings to keep in gallery. */
         const val MAX_GALLERY_SIZE = 12
         /** Maximum negative examples to store. */
@@ -500,38 +505,65 @@ class ReacquisitionEngine(
         val candBox = candidate.boundingBox
 
         // --- Appearance signal (computed early for override checks) ---
+        // For person candidates with OSNet on both sides, gate on OSNet (a real
+        // re-ID model) instead of MobileNetV3 (a generic ImageNet classifier
+        // that's blind to person-instance identity). MobileNetV3 still drives
+        // the ranking signals for non-person candidates and for persons that
+        // didn't get OSNet computed.
+        val candidateIsPerson = candidate.label == "person"
+        val hasReId = lockedIsPerson && candidateIsPerson &&
+            lockedReIdEmbedding != null && candidate.reIdEmbedding != null
+        val reIdScore = if (hasReId) {
+            cosineSimilarity(lockedReIdEmbedding!!, candidate.reIdEmbedding!!).coerceIn(0f, 1f)
+        } else 0f
+
         val hasAppearance = hasEmbeddings && candidate.embedding != null
-        val appearanceScore = if (hasAppearance) {
+        val mobileNetScore = if (hasAppearance) {
             bestGallerySimilarity(candidate.embedding!!).coerceIn(0f, 1f)
         } else 0f
+
+        val appearanceScore = if (hasReId) reIdScore else mobileNetScore
+        val gateActive = hasReId || hasAppearance
+
         // --- GATE: Require embedding when gallery exists ---
         // If we have reference embeddings but the candidate has none (async not ready),
         // reject it — accepting without identity verification causes wrong-object locks.
-        // Always require embeddings. The async pipeline delivers within 2-3 frames.
-        // Accepting without embeddings leads to wrong-category reacquisitions
-        // (e.g. laptop accepted when tracking chair, scored on position alone).
-        if (hasEmbeddings && candidate.embedding == null) {
+        // Exception: if hasReId, OSNet alone is sufficient for the gate (the
+        // candidate has been identified by a real re-ID model).
+        if (hasEmbeddings && candidate.embedding == null && !hasReId) {
             return null
         }
         val galleryMature = _embeddingGallery.size >= 8
 
-        // --- GATE: Embedding floor (gallery-relative) ---
-        // Instead of a fixed floor, adapt to how consistent the gallery is.
-        // A tight gallery (min pair sim=0.8) demands higher similarity from candidates.
-        // A diverse gallery (min pair sim=0.4) is more lenient.
-        // Floor = minGallerySim * 0.75, clamped to [0.3, 0.5].
-        val adaptiveFloor = (_minGallerySim * 0.75f).coerceIn(0.3f, 0.5f)
-        val embeddingFloor = if (galleryMature) maxOf(adaptiveFloor, 0.4f) else adaptiveFloor
-        if (hasAppearance && appearanceScore < embeddingFloor) {
-            addNegativeExample(candidate.embedding!!)
+        // --- GATE: Embedding floor ---
+        // For OSNet-gated persons: static floor tuned for Market-1501-style cosine
+        // distribution (typical same-person >= 0.5, different-person <= 0.4).
+        // For MobileNetV3-gated everything else: adaptive floor relative to gallery.
+        val embeddingFloor = if (hasReId) {
+            PERSON_REID_FLOOR
+        } else {
+            val adaptiveFloor = (_minGallerySim * 0.75f).coerceIn(0.3f, 0.5f)
+            if (galleryMature) maxOf(adaptiveFloor, 0.4f) else adaptiveFloor
+        }
+        // Don't poison the negative pool with rejections during search — when
+        // the floor is misconfigured (failure case), the locked person gets
+        // repeatedly rejected and added as a negative, training the prototype
+        // margin/classifier to actively reject the right answer next time.
+        // Negatives are still collected during confirmed VT tracking (addSceneNegative
+        // with its 0.85 filter handles that).
+        if (gateActive && appearanceScore < embeddingFloor) {
             return null
         }
 
         // Tiered override: geometric gates use a lower threshold (0.55) because
         // position rejection is about camera movement, not identity confusion.
         // Label gate uses a higher threshold (0.7) to protect against cross-category leakage.
-        val geometricOverride = hasAppearance && appearanceScore > GEOMETRIC_OVERRIDE_THRESHOLD
-        val labelOverride = hasAppearance && appearanceScore > APPEARANCE_OVERRIDE_THRESHOLD
+        // Use whichever embedding actually drove the gate (OSNet for person-person,
+        // MobileNetV3 otherwise) — OSNet's same-person sim often clears 0.55 even
+        // when MobileNetV3 doesn't, so this lets a strong re-ID match bypass
+        // position/size hard filters during fast camera movement.
+        val geometricOverride = gateActive && appearanceScore > GEOMETRIC_OVERRIDE_THRESHOLD
+        val labelOverride = gateActive && appearanceScore > APPEARANCE_OVERRIDE_THRESHOLD
 
         // --- GATE A: Position hard filter (with time decay) ---
         // Use velocity-predicted position when available. If the subject was moving
@@ -576,10 +608,8 @@ class ReacquisitionEngine(
         // Binary gate: a locked person only accepts person candidates, and vice versa.
         // Specific labels don't matter — embedding handles identity within each bucket.
         // This eliminates label flicker problems (bowl/potted plant, deer/sheep/dog).
-        val candidateIsPerson = candidate.label == "person"
+        // (candidateIsPerson computed earlier; reused here.)
         if (lockedIsPerson != candidateIsPerson && !labelOverride) {
-            // Store as negative example — helps sharpen identity boundary
-            if (hasAppearance) addNegativeExample(candidate.embedding!!)
             return null  // REJECT: person/non-person mismatch
         }
         if (lockedIsPerson != candidateIsPerson && labelOverride) {
@@ -606,11 +636,8 @@ class ReacquisitionEngine(
             cosineSimilarity(lockedFaceEmbedding!!, candidate.faceEmbedding!!).coerceIn(0f, 1f)
         } else 0f
 
-        // Re-ID embedding: strong person identity signal (when available)
-        val hasReId = lockedReIdEmbedding != null && candidate.reIdEmbedding != null
-        val reIdScore = if (hasReId) {
-            cosineSimilarity(lockedReIdEmbedding!!, candidate.reIdEmbedding!!).coerceIn(0f, 1f)
-        } else 0f
+        // Re-ID score (hasReId / reIdScore) computed earlier for the OSNet gate;
+        // reused here as the dominant ranking signal for person candidates.
 
         // No label bonus — person/not-person gate handles category, embedding handles identity
 

--- a/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
@@ -473,9 +473,12 @@ class ReacquisitionEngine(
         // asks "can the embedder tell these apart?" not "do other signals differ?"
         // Two candidates with similar embedding but different color/position are still
         // ambiguous from an identity standpoint — other signals are noisy tiebreakers.
+        // Uses the SAME embedding signal that drove the gate (OSNet for person-person,
+        // MobileNetV3 elsewhere). Otherwise ambiguity-by-MobileNetV3 could falsely
+        // reject pairs that OSNet clearly distinguishes (#67 review).
         if (sortedScored.size >= 2 && hasEmbeddings) {
-            val bestSim = if (best.first.embedding != null) bestGallerySimilarity(best.first.embedding!!) else 0f
-            val secondSim = if (sortedScored[1].first.embedding != null) bestGallerySimilarity(sortedScored[1].first.embedding!!) else 0f
+            val bestSim = effectiveAppearanceSim(best.first)
+            val secondSim = effectiveAppearanceSim(sortedScored[1].first)
             if (bestSim > 0f && secondSim > 0f) {
                 val ratio = secondSim / bestSim
                 if (ratio > RATIO_TEST_THRESHOLD) {
@@ -724,6 +727,24 @@ class ReacquisitionEngine(
     /** Best cosine similarity between a candidate and any embedding in the gallery. */
     internal fun bestGallerySimilarity(candidateEmbedding: FloatArray): Float {
         return bestGallerySimilarity(candidateEmbedding, _embeddingGallery)
+    }
+
+    /**
+     * Effective appearance similarity used by the gate, scoring, and ratio test.
+     * Matches the OSNet-vs-MobileNetV3 split in [scoreCandidate]: person-person
+     * comparisons (both sides have OSNet) use OSNet cosine; everything else
+     * uses MobileNetV3 against the gallery.
+     */
+    private fun effectiveAppearanceSim(candidate: TrackedObject): Float {
+        val candidateIsPerson = candidate.label == "person"
+        val hasReId = lockedIsPerson && candidateIsPerson &&
+            lockedReIdEmbedding != null && candidate.reIdEmbedding != null
+        return when {
+            hasReId -> cosineSimilarity(lockedReIdEmbedding!!, candidate.reIdEmbedding!!).coerceIn(0f, 1f)
+            hasEmbeddings && candidate.embedding != null ->
+                bestGallerySimilarity(candidate.embedding!!).coerceIn(0f, 1f)
+            else -> 0f
+        }
     }
 
     /** Log to both logcat and session file. */

--- a/app/src/test/java/com/haptictrack/tracking/ReacquisitionEngineTest.kt
+++ b/app/src/test/java/com/haptictrack/tracking/ReacquisitionEngineTest.kt
@@ -1149,7 +1149,7 @@ class ReacquisitionEngineTest {
     }
 
     @Test
-    fun `reId tier scores matching body higher than mismatching`() {
+    fun `reId tier rejects clearly-mismatching person via OSNet gate (#67)`() {
         val emb = floatArrayOf(0.5f, 0.5f)
         val reIdEmb = floatArrayOf(0.9f, 0.3f, 0.1f, 0.2f)
         engine.lock(42, RectF(0.4f, 0.4f, 0.6f, 0.6f), "person",
@@ -1164,11 +1164,14 @@ class ReacquisitionEngineTest {
             label = "person", embedding = emb,
             reIdEmbedding = floatArrayOf(0.1f, 0.1f, 0.9f, 0.1f)) // low re-ID sim
 
-        val matchScore = engine.scoreCandidate(matchBody, engine.lastKnownBox!!)!!
-        val wrongScore = engine.scoreCandidate(wrongBody, engine.lastKnownBox!!)!!
+        val matchScore = engine.scoreCandidate(matchBody, engine.lastKnownBox!!)
+        val wrongScore = engine.scoreCandidate(wrongBody, engine.lastKnownBox!!)
 
-        assertTrue("Matching re-ID ($matchScore) should beat mismatching ($wrongScore)",
-            matchScore > wrongScore)
+        // Pre-#67: both scored, ranking favored the match.
+        // Post-#67: OSNet sim is the gate for persons. Clearly-mismatching reId
+        // (cosine ~0.27) is below PERSON_REID_FLOOR (0.45) → hard reject.
+        assertNotNull("Matching re-ID should pass the OSNet gate", matchScore)
+        assertNull("Clearly-mismatching re-ID should be gate-rejected", wrongScore)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Gate person candidates on OSNet (a real re-ID model) instead of MobileNetV3 (a generic ImageNet classifier blind to person-instance identity).
- Stop adding rejected candidates to the negative pool during search — pre-fix, the locked person was being repeatedly added as a negative and the system was training itself to reject the right answer.
- Compute OSNet for every person candidate during search, not just top-2 by MobileNetV3. Without this, the wrong person could rank higher on MobileNetV3 and OSNet wouldn't run on the right one.
- Stacked on #71. Merge order: #63 → #64 → #66 → #71 → this.

## The bug

Live-camera capture (\`session_20260424_203704_person\`):
- Locked on a person, near full-frame.
- After LOST, FrameToFrameTracker correctly matched the same physical person (id=234) for 50+ frames at IoU 70-88%.
- ReacquisitionEngine rejected **all 97** of them at \`(hard threshold)\`, sim ∈ [0.08, 0.34] (MobileNetV3).
- OSNet \`reIdEmbedding\` was being computed every frame. Cosine to the lock-time OSNet embedding sat at 0.836 — strong same-person signal — and **was thrown away unread** because the candidate never passed the MobileNetV3 floor.

The whole identity stack downstream of MobileNetV3 was effectively dead code in the failure case.

## On-device video replay results (Snapdragon 870)

| Test | Pre-PR1 baseline | This PR |
|---|---|---|
| \`man_desk_camera_swing\` | 78% | 79–81% (within run-to-run noise) |
| \`person_playground\` | 90% | **99%** |
| \`boy_indoor_wife_swap\` | 30% threshold (known buggy: \"jumps from son to wife\") | **86%** |

The \`boy_indoor_wife_swap\` result is the headline. That test had a 30% tracking-rate threshold deliberately set low because of the documented \"tracking jumps from son to wife\" bug. PR1 brought it to 86% — nearly 3× the threshold, with 17 reacquires over 1347 frames all correctly labeled \`person\` and long stable stretches between losses.

## What changed (line-level)

**\`ReacquisitionEngine.scoreCandidate\` (lines ~500-555)**:
- Compute \`hasReId = lockedIsPerson && candidateIsPerson && both have reIdEmbedding\` early, before the gate.
- For \`hasReId\` candidates, set \`appearanceScore = cosineSimilarity(lockedReIdEmbedding, candidate.reIdEmbedding)\` (OSNet).
- Otherwise unchanged: \`appearanceScore = bestGallerySimilarity(candidate.embedding)\` (MobileNetV3).
- New floor \`PERSON_REID_FLOOR = 0.45f\` for the OSNet path. Tuned for Market-1501-style cosine distribution: same-person ≥ 0.5, different-person ≤ 0.4. Live-capture data point: same-person reId=0.836 vs MobileNetV3 sim=0.558.
- \`geometricOverride\` and \`labelOverride\` now use the effective \`appearanceScore\` (OSNet for person-person), so a strong re-ID match correctly bypasses position/size hard filters during fast camera movement.

**\`ReacquisitionEngine.scoreCandidate\` (rejection paths)**:
- Removed \`addNegativeExample(candidate.embedding!!)\` calls at the embedding-floor reject and the person/non-person mismatch reject. Negatives are still collected during confirmed VT tracking via \`addSceneNegative\` with its 0.85 sim filter — that path is correct.

**\`ObjectTracker.computeEmbeddingsSync\`**:
- Removed the \`.take(2)\` filter on person candidates. OSNet (and face when \`lockedFaceEmbedding != null\`) is now computed for every person candidate with an embedding.

**\`ObjectTracker\` sync embedding fallback**:
- For person candidates, also computes OSNet (and face) sync alongside MobileNetV3, so the new gate works end-to-end on freshly-detected persons. Sync result cache (\`SyncEmbedEntry\`) extended to hold the extra embeddings.

## Why this is safe

- \`hasReId\` requires both sides to have OSNet embeddings. If OSNet isn't computed (non-person, or async hasn't caught up and sync fallback didn't fire), the path falls back to the existing MobileNetV3 floor logic. No behavior change for non-person locks.
- The negative-poisoning fix is strictly less aggressive than before. We can no longer accidentally train against the locked person; we never train aggressively for separation either, which is fine because the gate now does the heavy lifting.
- 229 existing unit tests pass. One test was updated to reflect the new gate behavior (clearly-mismatching reId is now hard-rejected; previously was scored low in the weighted average — semantically equivalent intent).

## Test plan
- [x] Unit tests pass (229)
- [x] Build + deploy to device
- [x] On-device video replay: man_desk, person_playground, boy_indoor_wife_swap — all pass with material improvement
- [x] Live tracking on device: lock on person, walk around, reacquire correctly
- [ ] Capture a fresh two-people indoor scene + add as scenario fixture → tighten \`two_people_indoor.json\` thresholds (left for #70 follow-up)

## What this does NOT fix (out of scope)
- Vehicles / two-cars confusion → that's #69 (PR3, embedder swap).
- Per-lock adaptive floor → that's #68 (PR2).
- FTFTracker ID instability → that's #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)