### PR TITLE
Search path: prefer-by-ID cache merge + sync-embed dedup (#62 B2) [#64 reopened]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,8 +348,8 @@ Three-stage cycle on volume-down: idle → lock on center object, tracking → s
 ### GPU delegate for all models (decided 2026-04-18, updated 2026-04-19)
 All 9 ML models run on GPU. EfficientDet-Lite2 switched from INT8 (CPU) to FP16 (GPU) — downloaded from MediaPipe model zoo, same structure (448x448, 90 classes), fewer spurious detections. TFLite models use `createGpuInterpreter()` which returns `GpuInterpreter` (interpreter + delegate pair) with `Throwable` catch for CPU fallback. MediaPipe models use `Delegate.GPU` via `BaseOptions.setDelegate()`. InteractiveSegmenter GPU has a crop size limit — Adreno 740 returns empty masks above ~100K pixels, so large crops are downscaled to ~300x300 before segmenting (MAX_SEGMENT_PIXELS = 90000).
 
-### Adaptive frame skipping during visual tracking (decided 2026-04-18)
-When VitTracker is confident (>0.6) and has 5+ confirmed frames with 0 unconfirmed, skip the EfficientDet detector every other frame. VT alone runs at ~5ms vs ~35ms for detector. Still runs detector every 2nd frame for drift detection. Saves ~50% detector compute while locked. Resets on drift, lock clear, or VT stop.
+### Adaptive frame skipping during visual tracking (decided 2026-04-18, widened 2026-04-24)
+Two-tier skip interval. **Base regime** (confidence >0.6, confirmed ≥5, 0 unconfirmed): run detector every 2nd frame (~50% skipped). **Stable regime** (confidence >0.7, confirmed ≥10): run detector every 3rd frame (~67% skipped). VT alone runs at ~5ms vs ~35ms for detector. Template self-verification (#45, every 5 frames) is the primary drift signal now, so the detector cadence can be a slower safety net once VT has been stable for a while. Resets on drift, lock clear, or VT stop.
 
 ## Logging
 
@@ -490,8 +490,11 @@ All in constructor defaults — no settings UI yet:
 | `targetFrameOccupancy` | ZoomController | 0.15 | Target subject size as fraction of frame |
 | `zoomSpeed` | ZoomController | 0.05 | Zoom change per frame |
 | `scoreThreshold` | ObjectTracker (MediaPipe) | 0.5 | MediaPipe detector confidence cutoff |
-| `VT_SKIP_INTERVAL` | ObjectTracker | 2 | Run detector every Nth frame when VT is skipping |
+| `VT_SKIP_INTERVAL_BASE` | ObjectTracker | 2 | Default skip interval (50% detector frames) |
+| `VT_SKIP_INTERVAL_STABLE` | ObjectTracker | 3 | Widened interval when VT is long-stable (33% detector frames) |
 | `VT_SKIP_MIN_CONFIRMED` | ObjectTracker | 5 | Min VT confirmations before frame skipping kicks in |
+| `VT_SKIP_STABLE_CONFIRMED` | ObjectTracker | 10 | Confirmations required to switch to the stable skip interval |
+| `VT_SKIP_STABLE_CONFIDENCE` | ObjectTracker | 0.7 | VT confidence required to switch to the stable skip interval |
 
 ## What's Built vs. What's Not
 

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -55,8 +55,11 @@ class ObjectTracker(
 
     /** Skip detector every other frame when VT is confident and recently confirmed. */
     private var vtFrameCounter = 0
-    private val VT_SKIP_INTERVAL = 2  // run detector every Nth frame when skipping
-    private val VT_SKIP_MIN_CONFIRMED = 5  // need this many confirmations before skipping
+    private val VT_SKIP_INTERVAL_BASE = 2  // default: run detector every 2nd frame (50% skip)
+    private val VT_SKIP_INTERVAL_STABLE = 3  // highly confident + long-stable: every 3rd frame (67% skip)
+    private val VT_SKIP_MIN_CONFIRMED = 5  // need this many confirmations before skipping at all
+    private val VT_SKIP_STABLE_CONFIRMED = 10  // confirmations required for wider skip interval
+    private val VT_SKIP_STABLE_CONFIDENCE = 0.7f  // VT confidence required for wider skip interval
 
     /** Tracks object velocity for adaptive drift detection and position prediction. */
     private val velocityEstimator = VelocityEstimator()
@@ -267,11 +270,18 @@ class ObjectTracker(
 
                     // Skip detector when VT is confident and recently confirmed.
                     // Saves ~35ms per skipped frame. Still run every Nth frame for drift detection.
+                    // Widen the interval once VT has been confirmed for a long stretch at high
+                    // confidence — the detector's role at that point is a slow safety net,
+                    // template self-verification (every 5 frames) is the primary drift signal.
                     vtFrameCounter++
                     val canSkip = vtConfirmedFrames >= VT_SKIP_MIN_CONFIRMED &&
                         vtUnconfirmedFrames == 0 &&
                         vtResult.confidence > 0.6f
-                    val skipDetector = canSkip && (vtFrameCounter % VT_SKIP_INTERVAL != 0)
+                    val skipInterval = if (
+                        vtConfirmedFrames >= VT_SKIP_STABLE_CONFIRMED &&
+                        vtResult.confidence > VT_SKIP_STABLE_CONFIDENCE
+                    ) VT_SKIP_INTERVAL_STABLE else VT_SKIP_INTERVAL_BASE
+                    val skipDetector = canSkip && (vtFrameCounter % skipInterval != 0)
 
                     val tracked = if (skipDetector) {
                         emptyList()

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -109,6 +109,23 @@ class ObjectTracker(
         val cachedBox: RectF? = null
     )
 
+    /**
+     * Sync-fallback dedup cache. During search the sync fallback was firing on the
+     * same candidate ID every frame (~12 rejects/sec = ~280ms/sec of sync embed),
+     * because async results had moved out of IoU>0.3 range or hadn't arrived in time.
+     * We remember the last sync result per ID and reuse it while the box is still
+     * close to where we embedded it. Cleared on every lock/reacq transition.
+     */
+    private data class SyncEmbedEntry(
+        val embedding: FloatArray,
+        val colorHistogram: FloatArray?,
+        val cachedBox: RectF,
+        val framesLost: Int
+    )
+    private val recentSyncEmbeds = mutableMapOf<Int, SyncEmbedEntry>()
+    private val SYNC_EMBED_CACHE_FRAMES = 30  // ~1-2s at typical search fps; IoU is the real staleness guard
+    private val SYNC_EMBED_CACHE_IOU = 0.5f  // box must overlap this much with cached box
+
     /** Callback: (displayObjects, lockedObject, imageWidth, imageHeight, contour) */
     var onDetectionResult: ((List<TrackedObject>, TrackedObject?, Int, Int, List<PointF>) -> Unit)? = null
 
@@ -224,6 +241,7 @@ class ObjectTracker(
         velocityEstimator.reset()
         pendingEmbeddings?.cancel(true)
         pendingEmbeddings = null
+        recentSyncEmbeds.clear()
         cachedContour = emptyList()
         contourFrameCount = 0
     }
@@ -496,23 +514,33 @@ class ObjectTracker(
                 } catch (e: java.util.concurrent.TimeoutException) { emptyMap() }
                 catch (e: Exception) { emptyMap() }
 
-                // Merge cached embeddings into current detections by greedy IoU match.
-                // Each cached entry can only match one detection (prevents duplicates
-                // when overlapping boxes all match the same cached result).
+                // Merge cached embeddings into current detections. Prefer ID match
+                // (FTFTracker preserves IDs across frames for the same physical object —
+                // trust it), fall back to greedy IoU match for re-IDed detections.
+                // Prefer-by-ID avoids throwing away async work when fast motion pushes
+                // box-to-box IoU below 0.3 between consecutive frames.
                 val cachedEntries = cachedResults.entries.toList()
                 val usedCacheKeys = mutableSetOf<Int>()
                 val merged = withLabels.map { obj ->
-                    val bestMatch = cachedEntries
-                        .filter { (id, result) -> result.cachedBox != null && id !in usedCacheKeys }
-                        .maxByOrNull { (_, result) ->
+                    val byId = if (obj.id >= 0) cachedResults[obj.id] else null
+                    val cached: EmbeddingResult? = if (byId != null) {
+                        usedCacheKeys.add(obj.id)
+                        byId
+                    } else {
+                        val bestMatch = cachedEntries
+                            .filter { (id, result) -> result.cachedBox != null && id !in usedCacheKeys }
+                            .maxByOrNull { (_, result) ->
+                                computeIou(obj.boundingBox, result.cachedBox!!)
+                            }
+                        val iou = bestMatch?.let { (_, result) ->
                             computeIou(obj.boundingBox, result.cachedBox!!)
-                        }
-                    val iou = bestMatch?.let { (_, result) ->
-                        computeIou(obj.boundingBox, result.cachedBox!!)
-                    } ?: 0f
-                    if (bestMatch != null && iou > 0.3f) {
-                        usedCacheKeys.add(bestMatch.key)
-                        val cached = bestMatch.value
+                        } ?: 0f
+                        if (bestMatch != null && iou > 0.3f) {
+                            usedCacheKeys.add(bestMatch.key)
+                            bestMatch.value
+                        } else null
+                    }
+                    if (cached != null) {
                         obj.copy(
                             embedding = cached.embedding,
                             colorHistogram = cached.colorHistogram,
@@ -545,6 +573,11 @@ class ObjectTracker(
                 // identity gate hard-rejects these candidates, causing multi-second gaps.
                 // Fix: compute embedding synchronously for the single best same-category
                 // candidate that has no embedding. One-time ~23ms cost per new candidate.
+                //
+                // Dedup: a short-retention cache (recentSyncEmbeds) avoids re-embedding the
+                // same ID on consecutive frames — the same bad candidate used to cost ~23ms
+                // every frame because its sim never crossed the override threshold and
+                // the engine rejected it, leaving it "needsSync" again next frame.
                 val withSyncFallback = if (reacquisition.hasEmbeddings) {
                     val refBox = reacquisition.lastKnownBox
                     val lockedIsPerson = reacquisition.lockedIsPerson
@@ -560,17 +593,44 @@ class ObjectTracker(
                             val dy = obj.boundingBox.centerY() - refBox.centerY()
                             dx * dx + dy * dy
                         }!!
-                        // Compute embedding synchronously (raw crop fallback, ~8-23ms)
-                        val embResult = appearanceEmbedder.embedAndCrop(bitmap, best.boundingBox, fallback = true)
-                        val hist = if (embResult.maskedCrop != null) {
-                            val fullBox = RectF(0f, 0f, 1f, 1f)
-                            computeColorHistogram(embResult.maskedCrop, fullBox).also { embResult.maskedCrop.recycle() }
-                        } else computeColorHistogram(bitmap, best.boundingBox)
-                        if (embResult.embedding != null) {
-                            android.util.Log.d("EmbedSync", "Sync embedding for id=${best.id} label=${best.label}")
+
+                        // Dedup: reuse a recent sync result if this ID was embedded in
+                        // the last SYNC_EMBED_CACHE_FRAMES frames and its box hasn't moved.
+                        // Prune stale entries first so the map doesn't grow unbounded across
+                        // long searches where FTFTracker keeps minting new IDs.
+                        val currFramesLost = reacquisition.framesLost
+                        recentSyncEmbeds.entries.removeAll { (_, entry) ->
+                            currFramesLost - entry.framesLost >= SYNC_EMBED_CACHE_FRAMES
+                        }
+                        val cached = recentSyncEmbeds[best.id]
+                        val reusable = cached != null &&
+                            computeIou(best.boundingBox, cached.cachedBox) > SYNC_EMBED_CACHE_IOU
+
+                        val (embedding, hist) = if (reusable) {
+                            cached!!.embedding to cached.colorHistogram
+                        } else {
+                            // Compute embedding synchronously (raw crop fallback, ~8-23ms)
+                            val embResult = appearanceEmbedder.embedAndCrop(bitmap, best.boundingBox, fallback = true)
+                            val computedHist = if (embResult.maskedCrop != null) {
+                                val fullBox = RectF(0f, 0f, 1f, 1f)
+                                computeColorHistogram(embResult.maskedCrop, fullBox).also { embResult.maskedCrop.recycle() }
+                            } else computeColorHistogram(bitmap, best.boundingBox)
+                            if (embResult.embedding != null) {
+                                android.util.Log.d("EmbedSync", "Sync embedding for id=${best.id} label=${best.label}")
+                                recentSyncEmbeds[best.id] = SyncEmbedEntry(
+                                    embedding = embResult.embedding,
+                                    colorHistogram = computedHist,
+                                    cachedBox = RectF(best.boundingBox),
+                                    framesLost = currFramesLost
+                                )
+                            }
+                            embResult.embedding to computedHist
+                        }
+
+                        if (embedding != null) {
                             merged.map { obj ->
                                 if (obj.id == best.id) obj.copy(
-                                    embedding = embResult.embedding,
+                                    embedding = embedding,
                                     colorHistogram = hist
                                 ) else obj
                             }
@@ -581,6 +641,7 @@ class ObjectTracker(
                 withSyncFallback
             } else {
                 pendingEmbeddings = null // clear when not searching
+                recentSyncEmbeds.clear()
                 withLabels
             }
 


### PR DESCRIPTION
Reopens #64 (auto-closed when its base branch `perf/vt-skip-tuning-62` was deleted on #63's merge — stacked-PR gotcha).

Original PR: #64
Original review: approved.

Identical content; head branch unchanged. Squash-merge ready.