### PR TITLE
Drift detection: faster template path via decay + lock-only gallery (#80)

### DIFF
--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -74,14 +74,18 @@ class ObjectTracker(
      * so it catches drift even when the detector can't see the target
      * (small objects, uniform surfaces, label flicker).
      *
-     * Asymmetric thresholds (hysteresis): increment the counter when sim falls
-     * below TEMPLATE_SIM_LOW, reset only when sim rises above TEMPLATE_SIM_OK.
-     * This prevents oscillation around a single threshold from masking drift.
+     * Hysteresis: increment when sim < TEMPLATE_SIM_LOW, decrement (not reset)
+     * when sim > TEMPLATE_SIM_OK. The decrement-instead-of-reset semantics
+     * (#80 fix) means a single high-sim flicker doesn't undo two prior bad
+     * frames. Counter still trips at TEMPLATE_MISMATCH_MAX consecutive-ish
+     * low frames, but is robust to occasional flukes — exactly the case
+     * where the camera pans to uniform backdrop and sim flickers between
+     * 0.3 and 0.5.
      */
     private val TEMPLATE_CHECK_INTERVAL = 5    // embed VT crop every N frames
     private val TEMPLATE_SIM_LOW = 0.4f        // below this = drift suspicion (increment)
-    private val TEMPLATE_SIM_OK = 0.5f         // above this = safe (reset counter)
-    private val TEMPLATE_MISMATCH_MAX = 3      // consecutive low-sim checks → kill (≈0.5s)
+    private val TEMPLATE_SIM_OK = 0.5f         // above this = safe (decrement, floored at 0)
+    private val TEMPLATE_MISMATCH_MAX = 3      // mismatches → kill (≈0.5s)
     private var templateMismatchCount = 0
 
     /**
@@ -470,22 +474,33 @@ class ObjectTracker(
                     // Effective rate is every ~5 frames normally, ~10 frames when VT
                     // frame skipping is active (skipDetector=true on alternate frames).
                     //
-                    // Hysteresis: increment when sim < TEMPLATE_SIM_LOW, reset only
-                    // when sim > TEMPLATE_SIM_OK. Values in between (the dead zone)
-                    // leave the counter unchanged so marginal oscillation can't mask
-                    // real drift.
+                    // Hysteresis: increment when sim < TEMPLATE_SIM_LOW, decrement
+                    // (floored at 0) when sim > TEMPLATE_SIM_OK. Values in between
+                    // (the dead zone) leave the counter unchanged. Decrement instead
+                    // of full reset means a single high-sim flicker doesn't erase
+                    // two prior bad frames — fixes the slow-drift case in #80 where
+                    // panning to a uniform backdrop produced 0.3 / 0.5 / 0.3 / 0.5
+                    // patterns that kept the counter pinned at 1/3.
                     if (!skipDetector &&
                         reacquisition.hasEmbeddings &&
                         vtFrameCounter % TEMPLATE_CHECK_INTERVAL == 0) {
                         val curEmb = appearanceEmbedder.embedWithFallback(bitmap, rawBox)
                         if (curEmb != null) {
-                            val sim = reacquisition.bestGallerySimilarity(curEmb)
+                            // Use lock-time gallery only — accumulated entries
+                            // can include drifted VT crops that mask the drift
+                            // signal at sim=1.0. (#80)
+                            val sim = reacquisition.bestLockGallerySimilarity(curEmb)
                             when {
                                 sim < TEMPLATE_SIM_LOW -> {
                                     templateMismatchCount++
                                     android.util.Log.d("VisualTracker", "Template mismatch $templateMismatchCount/$TEMPLATE_MISMATCH_MAX (sim=${"%.3f".format(sim)})")
                                 }
-                                sim > TEMPLATE_SIM_OK -> templateMismatchCount = 0
+                                sim > TEMPLATE_SIM_OK -> {
+                                    if (templateMismatchCount > 0) {
+                                        templateMismatchCount--
+                                        android.util.Log.d("VisualTracker", "Template recovery $templateMismatchCount/$TEMPLATE_MISMATCH_MAX (sim=${"%.3f".format(sim)})")
+                                    }
+                                }
                                 else -> { /* dead zone — hold the counter */ }
                             }
                         }

--- a/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
@@ -730,6 +730,20 @@ class ReacquisitionEngine(
     }
 
     /**
+     * Best cosine similarity against the **lock-time** portion of the gallery only
+     * (the first `LOCK_AUGMENTATION_COUNT` entries — original + rotations + flip).
+     * Used by template self-verification (#80): if drift detection used the full
+     * gallery, accumulated-during-tracking entries can include drifted VT crops,
+     * which then match the (also drifted) VT crop perfectly and mask drift.
+     * The lock-time portion is fixed and trustworthy.
+     */
+    internal fun bestLockGallerySimilarity(candidateEmbedding: FloatArray): Float {
+        if (_embeddingGallery.isEmpty()) return 0f
+        val lockEntries = _embeddingGallery.take(LOCK_AUGMENTATION_COUNT)
+        return bestGallerySimilarity(candidateEmbedding, lockEntries)
+    }
+
+    /**
      * Effective appearance similarity used by the gate, scoring, and ratio test.
      * Matches the OSNet-vs-MobileNetV3 split in [scoreCandidate]: person-person
      * comparisons (both sides have OSNet) use OSNet cosine; everything else


### PR DESCRIPTION
## Summary
Two structural fixes that take template-driven drift detection from ~7-12s down to ~1.5-2s in the slow case (camera pans away from subject to uniform backdrop).

1. **Counter decays by 1 instead of full reset** on high-sim flicker — three mismatches over a slightly larger window still trip drift; a single fluke high-sim frame doesn't undo two prior bad frames.
2. **Drift detection compares against lock-time gallery only** (`LOCK_AUGMENTATION_COUNT = 5` entries) — accumulated entries that may contain drifted VT crops are excluded from the drift signal, eliminating self-cancellation at sim=1.0.

Either fix alone wasn't enough. Decay solves the flicker case, but gallery pollution made the recovery sim hit 1.0 anyway. Lock-only gallery solves the pollution, but without decay a single-frame 0.5+ would still reset the counter. Together they make the template path reliable.

## Diagnosis trace

The user's repro: lock person, pan camera away to uniform indoor backdrop. Pre-fix took 7-12s for DRIFT to fire.

**Before — flicker masking (decay fix target):**
```
12:44:51.662  Template mismatch 1/3 (sim=0.262)
12:44:54.323  Template mismatch 1/3 (sim=0.398)  ← counter still 1, never advanced
12:44:55.350  DRIFT — 11 unconfirmed frames (~12s)  ← detector fallback
```

**Mid-fix (decay applied, pollution still present):**
```
Template mismatch 1/3 (sim=0.303)
Template recovery 0/3 (sim=0.897)   ← sim=0.897 because polluted gallery contained drifted crops
Template mismatch 1/3 (sim=0.089)
Template recovery 0/3 (sim=1.000)   ← sim=1.000 = self-match against just-added drifted gallery entry
... endless cycling, user gives up and clears
```

**After — both fixes (this PR):**
```
13:00:16.193  Template mismatch 1/3 (sim=0.390)
13:00:16.960  Template mismatch 2/3 (sim=0.334)
13:00:17.677  Template mismatch 3/3 (sim=0.310)
13:00:17.677  DRIFT — template mismatch 3x  ← 1.5s total
```

Recovery sim now ~0.5 against the fixed lock gallery, not ~1.0 against polluted accumulated gallery.

## What changed

**`ObjectTracker.kt`**:
- Template-mismatch handling: \`sim > TEMPLATE_SIM_OK\` decrements by 1 (floored at 0) instead of full reset to 0. New \`Template recovery N/3\` log line.
- Template self-verification calls \`bestLockGallerySimilarity\` instead of \`bestGallerySimilarity\`.

**`ReacquisitionEngine.kt`**:
- New \`bestLockGallerySimilarity()\` that compares only against the first \`LOCK_AUGMENTATION_COUNT = 5\` gallery entries. Reacquisition path still uses the full gallery (different signal — coverage matters there, not stability).

## Why this is safe

- Reacquisition behavior unchanged: \`bestGallerySimilarity\` (full gallery) still drives gating, scoring, ratio test.
- Drift detection thresholds (\`TEMPLATE_SIM_LOW = 0.4\`, \`TEMPLATE_SIM_OK = 0.5\`, \`TEMPLATE_MISMATCH_MAX = 3\`) unchanged.
- VT confidence floor and \`VT_MAX_UNCONFIRMED\` paths unchanged — they still serve as backup drift signals.
- 229 unit tests pass.

## Test plan
- [x] Unit tests pass (229)
- [x] Build + deploy to device
- [x] Manual repro of the slow-case scenario shows ~1.5-2s drift detection (vs 7-12s pre-fix)
- [x] No regression on the fast-case scenario (camera lands on visually distinct content) — still trips at 3 in 1-1.5s
- [ ] Capture a new scenario specifically for this case as a replay-test fixture

## Related
- Issue: #80
- Trace data: #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)