### PR TITLE
Identity: face embedding as a gate (#83 phase 1)

### DIFF
--- a/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ReacquisitionEngine.kt
@@ -49,6 +49,14 @@ class ReacquisitionEngine(
          *  different-person sim in [0.2, 0.4]. 0.45 sits in the gap. Tuned from a live
          *  capture where same-person reId hit 0.836 while MobileNetV3 sim was 0.558. */
         const val PERSON_REID_FLOOR = 0.45f
+        /** Face embedding (MobileFaceNet, ArcFace-style) cosine floor for person identity.
+         *  Same-person face sim typically >= 0.5; different-person face sim typically
+         *  <= 0.3. 0.4 sits in the gap. When both lock and candidate have face
+         *  embeddings, face VETOES OSNet — even a high reId sim gets rejected if face
+         *  says different. Catches the case where OSNet's whole-body sim sits in
+         *  the wrong-person 0.55-0.70 band but face cleanly separates identity.
+         *  Filed as #83. */
+        const val FACE_FLOOR = 0.40f
         /** Maximum embeddings to keep in gallery. */
         const val MAX_GALLERY_SIZE = 12
         /** Maximum negative examples to store. */
@@ -556,6 +564,23 @@ class ReacquisitionEngine(
         // with its 0.85 filter handles that).
         if (gateActive && appearanceScore < embeddingFloor) {
             return null
+        }
+
+        // --- GATE: Face identity (#83) ---
+        // When both lock and candidate have face embeddings (person-person only),
+        // face vetoes OSNet. MobileFaceNet has cleaner same/different-person
+        // separation than OSNet's whole-body re-ID — a face sim < FACE_FLOOR is
+        // strong evidence of a different person, regardless of body match.
+        // Doesn't affect candidates without face data (rejection path goes
+        // through OSNet alone in those cases).
+        val hasFaceGate = lockedIsPerson && candidateIsPerson &&
+            lockedFaceEmbedding != null && candidate.faceEmbedding != null
+        if (hasFaceGate) {
+            val faceSim = cosineSimilarity(lockedFaceEmbedding!!, candidate.faceEmbedding!!).coerceIn(0f, 1f)
+            if (faceSim < FACE_FLOOR) {
+                dualLog(Log.DEBUG, "  FACE_GATE_REJECT: faceSim=${fmtF(faceSim)} < ${fmtF(FACE_FLOOR)} (reIdSim=${fmtF(reIdScore)})")
+                return null
+            }
         }
 
         // Tiered override: geometric gates use a lower threshold (0.55) because

--- a/app/src/test/java/com/haptictrack/tracking/ReacquisitionEngineTest.kt
+++ b/app/src/test/java/com/haptictrack/tracking/ReacquisitionEngineTest.kt
@@ -1125,7 +1125,7 @@ class ReacquisitionEngineTest {
     // --- Face and re-ID scoring tiers ---
 
     @Test
-    fun `face tier scores matching face higher than mismatching`() {
+    fun `face tier rejects clearly-mismatching face via face gate (#83)`() {
         val emb = floatArrayOf(0.5f, 0.5f)
         val faceEmb = floatArrayOf(0.9f, 0.3f, 0.1f)
         val reIdEmb = floatArrayOf(0.5f, 0.5f, 0.5f, 0.5f)
@@ -1139,13 +1139,16 @@ class ReacquisitionEngineTest {
             faceEmbedding = floatArrayOf(0.88f, 0.32f, 0.12f)) // high face sim
         val wrongFace = obj(id = 11, left = 0.42f, top = 0.42f, right = 0.62f, bottom = 0.62f,
             label = "person", embedding = emb, reIdEmbedding = reIdEmb,
-            faceEmbedding = floatArrayOf(0.1f, 0.1f, 0.9f)) // low face sim
+            faceEmbedding = floatArrayOf(0.1f, 0.1f, 0.9f)) // low face sim — different face
 
-        val matchScore = engine.scoreCandidate(matchFace, engine.lastKnownBox!!)!!
-        val wrongScore = engine.scoreCandidate(wrongFace, engine.lastKnownBox!!)!!
+        val matchScore = engine.scoreCandidate(matchFace, engine.lastKnownBox!!)
+        val wrongScore = engine.scoreCandidate(wrongFace, engine.lastKnownBox!!)
 
-        assertTrue("Matching face ($matchScore) should beat mismatching ($wrongScore)",
-            matchScore > wrongScore)
+        // Pre-#83: face was a scoring weight, both scored, ranking favored match.
+        // Post-#83: face is a GATE — clearly mismatching face (cosine ~0.10) below
+        // FACE_FLOOR (0.40) is hard-rejected. Body re-ID match doesn't rescue it.
+        assertNotNull("Matching face should pass the face gate", matchScore)
+        assertNull("Clearly-mismatching face should be gate-rejected", wrongScore)
     }
 
     @Test
@@ -1175,7 +1178,7 @@ class ReacquisitionEngineTest {
     }
 
     @Test
-    fun `face tier takes precedence over reId tier`() {
+    fun `face gate vetoes good body when face mismatches (#83)`() {
         val emb = floatArrayOf(0.5f, 0.5f)
         val reIdEmb = floatArrayOf(0.5f, 0.5f, 0.5f, 0.5f)
         val faceEmb = floatArrayOf(0.9f, 0.3f, 0.1f)
@@ -1184,22 +1187,25 @@ class ReacquisitionEngineTest {
             reIdEmbedding = reIdEmb, faceEmbedding = faceEmb)
         engine.processFrame(emptyList())
 
-        // Good face, bad re-ID
+        // Good face, bad re-ID — but bad re-ID is now also a gate, so this fails OSNet.
+        // To test face precedence, both face AND re-ID should pass for goodFace.
         val goodFace = obj(id = 10, left = 0.42f, top = 0.42f, right = 0.62f, bottom = 0.62f,
             label = "person", embedding = emb,
-            reIdEmbedding = floatArrayOf(0.1f, 0.1f, 0.1f, 0.9f), // bad re-ID
+            reIdEmbedding = floatArrayOf(0.48f, 0.52f, 0.48f, 0.52f), // re-ID passes (~0.99)
             faceEmbedding = floatArrayOf(0.88f, 0.32f, 0.12f)) // good face
-        // Bad face, good re-ID
+        // Good re-ID, bad face — face gate must veto despite passing OSNet
         val goodBody = obj(id = 11, left = 0.42f, top = 0.42f, right = 0.62f, bottom = 0.62f,
             label = "person", embedding = emb,
-            reIdEmbedding = floatArrayOf(0.48f, 0.52f, 0.48f, 0.52f), // good re-ID
-            faceEmbedding = floatArrayOf(0.1f, 0.1f, 0.9f)) // bad face
+            reIdEmbedding = floatArrayOf(0.48f, 0.52f, 0.48f, 0.52f), // good re-ID (~0.99)
+            faceEmbedding = floatArrayOf(0.1f, 0.1f, 0.9f)) // bad face (cosine ~0.10)
 
-        val faceScore = engine.scoreCandidate(goodFace, engine.lastKnownBox!!)!!
-        val bodyScore = engine.scoreCandidate(goodBody, engine.lastKnownBox!!)!!
+        val faceScore = engine.scoreCandidate(goodFace, engine.lastKnownBox!!)
+        val bodyScore = engine.scoreCandidate(goodBody, engine.lastKnownBox!!)
 
-        assertTrue("Good face ($faceScore) should beat good body ($bodyScore) — face takes precedence",
-            faceScore > bodyScore)
+        // Pre-#83: face was scoring-only, good-body would still score below good-face but pass.
+        // Post-#83: face is a gate — bad face vetoes despite good body re-ID match.
+        assertNotNull("Good face + good body should pass both gates", faceScore)
+        assertNull("Bad face vetoes good body via face gate", bodyScore)
     }
 
     @Test


### PR DESCRIPTION
## Summary
PR1 (#67) gated person candidates on OSNet at \`PERSON_REID_FLOOR = 0.45\`. On-device empirical: OSNet produces same-person sim 0.7-0.95 and **different-person sim 0.55-0.70** — wrong-person matches in the 0.55-0.70 band leak through the 0.45 floor.

This PR adds face embedding as a hard gate. When both lock and candidate have face embeddings (MobileFaceNet, ArcFace-style), face VETOES OSNet — a face sim < FACE_FLOOR (0.40) hard-rejects regardless of reId match.

## On-device verification (Snapdragon 870, 2026-04-25)

After locking on a person, panned camera to a different person whose face was visible. The face gate fired 20+ times in 1.5s:

\`\`\`
FACE_GATE_REJECT: faceSim=0.089 < 0.400 (reIdSim=0.679)
FACE_GATE_REJECT: faceSim=0.260 < 0.400 (reIdSim=0.695)
FACE_GATE_REJECT: faceSim=0.064 < 0.400 (reIdSim=0.630)
FACE_GATE_REJECT: faceSim=0.022 < 0.400 (reIdSim=0.639)
\`\`\`

All reId values in [0.63, 0.70] (would have passed PR1's gate alone, the documented #83 failure case). All face values in [0.06, 0.26] (clearly different face). Veto behaved correctly.

## What changed
- New \`FACE_FLOOR = 0.40f\` constant.
- New face gate in \`scoreCandidate\` after the embedding floor: when \`lockedFaceEmbedding != null && candidate.faceEmbedding != null\` for person-person, compute face cosine sim. Below 0.40 → \`return null\` with a \`FACE_GATE_REJECT\` log.

## What this PR does NOT fix
The no-face case. If the candidate has no face data (BlazeFace failed, distance, occlusion), the face gate doesn't fire and OSNet sim alone decides. Same test session showed a reacquire at \`reId=0.639\` with no face data, which still passed.

Phase 2 (color hist + person attrs as ANDed gates) is the follow-up for that case. Tracked in #83.

## Why face is the right primary gate

MobileFaceNet was trained explicitly for face identity (ArcFace metric learning on millions of identities), with cleaner same/different-person separation than OSNet's whole-body re-ID. When face is visible, it's the strongest single human-identity signal we compute. The 0.40 threshold sits in the gap between the typical same-person band (≥ 0.5) and different-person band (≤ 0.3).

## Tests
229 unit tests pass. Two pre-existing tests updated:
- \`face tier scores matching face higher than mismatching\` → \`face tier rejects clearly-mismatching face via face gate (#83)\` (assertion changed from "matchScore > wrongScore" to "matchScore != null, wrongScore == null").
- \`face tier takes precedence over reId tier\` → \`face gate vetoes good body when face mismatches (#83)\` (same shift — face is now a gate, not a scoring weight).

## Test plan
- [x] Unit tests pass (229)
- [x] Build + deploy
- [x] On-device repro: pan camera to different person with face visible — face gate vetoes correctly
- [ ] Capture this scenario as a replay test fixture for regression
- [ ] Phase 2: color + attrs ANDed gates for the no-face case

🤖 Generated with [Claude Code](https://claude.com/claude-code)