### PR TITLE
Synthetic stock-video tests for person identity (#62)

### DIFF
--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -334,6 +334,27 @@ class VideoReplayTest {
             "totalFrames=${result.totalFrames}")
     }
 
+    // person_distance: synthetic stock-video test (Pexels 5320110, cottonbro studio,
+    // CC0). 13.6s — single shirtless man with distinctive tattoos walks from
+    // mid-distance toward camera, ending at close-up. Tests scale tolerance:
+    // gallery embeddings learned from a small crop (~12% of frame height at
+    // lock time) must continue to match as the subject grows ~6× over the clip.
+    // Adaptive size threshold and re-id at varied scale are exercised here.
+
+    @Test
+    fun person_distance_tracking_through_scale_change() {
+        val result = replayVideo("person_distance")
+
+        // Single-subject video — no wrong-person assertion is meaningful here.
+        // Primary signal is whether tracking survives the scale change. A timeout
+        // means the gallery couldn't bridge the small→large transition.
+        assertFalse("Should not timeout", result.timedOut)
+
+        Log.i(TAG, "person_distance: trackingRate=${result.trackingRate}% " +
+            "reacqs=${result.reacquisitions} losses=${result.losses} " +
+            "totalFrames=${result.totalFrames}")
+    }
+
     // --- Replay infrastructure ---
 
     data class ReplayEvent(

--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -355,6 +355,32 @@ class VideoReplayTest {
             "totalFrames=${result.totalFrames}")
     }
 
+    // crowd_street: synthetic stock-video test (Pexels 12699538, CC0). 12.2s
+    // portrait shot of a busy market street — six detected persons in the lock
+    // frame alone. Lock target picked via EfficientDet-Lite2 detection (the
+    // same model the app uses) so the box is what the production detector
+    // would produce. Tests reacquisition through occlusion and discrimination
+    // among many same-category candidates at once.
+
+    @Test
+    fun crowd_street_no_wrong_category_lock() {
+        val result = replayVideo("crowd_street")
+
+        // The dense-multi-person scene means an "A→B" person swap is invisible
+        // to PERSON_LABELS. Primary signals: no timeout (the lock should be
+        // reacquired through brief occlusions) and tracking rate that doesn't
+        // collapse (catastrophic mistracking would push it near zero).
+        assertFalse("Should not timeout", result.timedOut)
+
+        val wrong = result.wrongCategoryReacqs(PERSON_LABELS)
+        assertTrue("Should never reacquire non-person (got: ${wrong.map { "${it.label}@F${it.frame}" }})",
+            wrong.isEmpty())
+
+        Log.i(TAG, "crowd_street: trackingRate=${result.trackingRate}% " +
+            "reacqs=${result.reacquisitions} losses=${result.losses} " +
+            "totalFrames=${result.totalFrames}")
+    }
+
     // --- Replay infrastructure ---
 
     data class ReplayEvent(

--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -279,6 +279,61 @@ class VideoReplayTest {
             result.trackingRate >= 25)
     }
 
+    // two_men_forest: synthetic stock-video test (Pexels 4830416, cottonbro studio,
+    // CC0). Two men with similar earth-tone outdoor clothing walk down a path.
+    // Probes person identity discrimination when color histogram alone can't tell
+    // them apart — the face gate (#84) and body re-id (OSNet) have to do the work.
+    // The two subjects differ in age (younger / bearded older), so face is a
+    // genuine discriminator if it can fire.
+
+    @Test
+    fun two_men_forest_no_wrong_person_lock() {
+        val result = replayVideo("two_men_forest")
+
+        // Baseline TBD on first device run. Primary assertion is that the lock
+        // never reacquires onto a wrong subject — the other man is consistently
+        // visible alongside the locked one. PERSON_LABELS is the wrong scope here
+        // because both subjects ARE people; the test design captures this video's
+        // value via tracking rate (a wrong-person reacquire would drop it sharply).
+        assertFalse("Should not timeout", result.timedOut)
+
+        val wrong = result.wrongCategoryReacqs(PERSON_LABELS)
+        assertTrue("Should never reacquire non-person (got: ${wrong.map { "${it.label}@F${it.frame}" }})",
+            wrong.isEmpty())
+
+        Log.i(TAG, "two_men_forest: trackingRate=${result.trackingRate}% " +
+            "reacqs=${result.reacquisitions} losses=${result.losses} " +
+            "totalFrames=${result.totalFrames}")
+    }
+
+    // two_men_suits: synthetic stock-video test (Pexels 8915048, Kampus Production,
+    // CC0). 8s — four persons in frame: two men in nearly-identical black suits
+    // with bow ties side-by-side, a third man in a gray jacket, and a woman in
+    // a patterned blouse. Lock target is the lighter-haired suit man (3rd from
+    // left). Tests the color-histogram-can't-discriminate case — the man directly
+    // beside the lock target wears identical clothing. Hair color and face are
+    // the discriminators.
+
+    @Test
+    fun two_men_suits_no_wrong_person_lock() {
+        val result = replayVideo("two_men_suits")
+
+        // Baseline TBD on first device run. 198 frames is short — primary signal
+        // is "no wrong-category reacquire" since both suit men are 'person' and
+        // the test can't tell them apart at the assertion layer. Tracking rate
+        // is a secondary indicator — a sharp drop suggests the lock jumped to
+        // the other suit-wearing subject.
+        assertFalse("Should not timeout", result.timedOut)
+
+        val wrong = result.wrongCategoryReacqs(PERSON_LABELS)
+        assertTrue("Should never reacquire non-person (got: ${wrong.map { "${it.label}@F${it.frame}" }})",
+            wrong.isEmpty())
+
+        Log.i(TAG, "two_men_suits: trackingRate=${result.trackingRate}% " +
+            "reacqs=${result.reacquisitions} losses=${result.losses} " +
+            "totalFrames=${result.totalFrames}")
+    }
+
     // --- Replay infrastructure ---
 
     data class ReplayEvent(

--- a/tools/synthetic_test_videos/crowd_street.json
+++ b/tools/synthetic_test_videos/crowd_street.json
@@ -1,0 +1,10 @@
+{
+  "_source": "Pexels video 12699538 'Crowd of People Walking in a City Street' (CC0). 12.2s portrait shot of a busy market street with dozens of pedestrians at varied distances. Six person detections in the lock frame alone — the densest scene in the test suite by far.",
+  "_lockTarget": "Detection #1 from EfficientDet-Lite2 — foreground subject in the left-center of frame 30 (~21-41% horizontal, ~51-91% vertical, 8.1% of frame area). Five other detected persons share the frame at lock time. Tests reacquisition through occlusion and discrimination among many same-category candidates simultaneously.",
+  "_caveat": "We can't tell if the lock 'jumps' to a different person mid-track — both are 'person' to the assertion layer. Same blind spot as boy_indoor_wife_swap. Primary signal is no timeout + no obvious tracking-rate collapse.",
+  "lockFrame": 30,
+  "lockBox": [0.212, 0.512, 0.415, 0.915],
+  "lockLabel": "person",
+  "analysisWidth": 640,
+  "fps": 60
+}

--- a/tools/synthetic_test_videos/detect_persons.py
+++ b/tools/synthetic_test_videos/detect_persons.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Run EfficientDet-Lite2 (same model as the app) on a frame and print
+person bboxes in normalized coords. Used to pick a clean lockBox without a
+GUI annotator."""
+import sys
+from pathlib import Path
+import mediapipe as mp
+from mediapipe.tasks import python as mp_python
+from mediapipe.tasks.python import vision
+
+if len(sys.argv) != 2:
+    print("usage: detect_persons.py <frame.png>")
+    sys.exit(1)
+
+frame_path = Path(sys.argv[1])
+model_path = Path(__file__).parent.parent.parent / "app/src/main/assets/efficientdet-lite2-fp16.tflite"
+
+base_options = mp_python.BaseOptions(model_asset_path=str(model_path))
+options = vision.ObjectDetectorOptions(
+    base_options=base_options,
+    score_threshold=0.5,
+    max_results=20,
+)
+detector = vision.ObjectDetector.create_from_options(options)
+img = mp.Image.create_from_file(str(frame_path))
+result = detector.detect(img)
+
+w, h = img.width, img.height
+print(f"image: {w}x{h}")
+print(f"detections: {len(result.detections)}")
+for i, det in enumerate(result.detections):
+    bbox = det.bounding_box
+    cat = det.categories[0]
+    if cat.category_name != "person":
+        continue
+    nl = bbox.origin_x / w
+    nt = bbox.origin_y / h
+    nr = (bbox.origin_x + bbox.width) / w
+    nb = (bbox.origin_y + bbox.height) / h
+    area = (bbox.width / w) * (bbox.height / h)
+    print(f"  #{i} person score={cat.score:.3f} box=[{nl:.3f},{nt:.3f},{nr:.3f},{nb:.3f}] area={area:.4f}")

--- a/tools/synthetic_test_videos/person_distance.json
+++ b/tools/synthetic_test_videos/person_distance.json
@@ -1,0 +1,10 @@
+{
+  "_source": "Pexels video 5320110 'A Man Walking Towards the Camera' by cottonbro studio (CC0). Trimmed to 13.6s starting from where subject is at moderate scale. Single subject — shirtless man with distinctive tattoos walks from mid-distance to close-up.",
+  "_lockTarget": "Lone subject at center frame, ~12% of frame height at lock time. Tests scale tolerance: gallery embeddings learned from a small crop must continue to match as the subject grows ~6× over the clip. Adaptive size threshold and re-id at varied scale also exercised.",
+  "_caveat": "Single-subject video — no wrong-person assertion is meaningful. Primary signal is whether tracking survives the scale change.",
+  "lockFrame": 0,
+  "lockBox": [0.460, 0.430, 0.535, 0.730],
+  "lockLabel": "person",
+  "analysisWidth": 640,
+  "fps": 25
+}

--- a/tools/synthetic_test_videos/two_men_forest.json
+++ b/tools/synthetic_test_videos/two_men_forest.json
@@ -1,0 +1,9 @@
+{
+  "_source": "Pexels video 4830416 'Two Men Walking in the Forest' by cottonbro studio (CC0). Trimmed to last ~17s where both men are walking close to camera at moderate scale. Tests person identity discrimination when two subjects share similar earth-tone outdoor clothing.",
+  "_lockTarget": "Left figure (younger, darker olive jacket). The right figure (older, white-bearded, lighter olive) is consistently nearby — probes wrong-person discrimination via face gate (different ages) + body re-id.",
+  "lockFrame": 0,
+  "lockBox": [0.297, 0.370, 0.375, 0.754],
+  "lockLabel": "person",
+  "analysisWidth": 640,
+  "fps": 25
+}

--- a/tools/synthetic_test_videos/two_men_suits.json
+++ b/tools/synthetic_test_videos/two_men_suits.json
@@ -1,0 +1,10 @@
+{
+  "_source": "Pexels video 8915048 'Men Wearing Suit Walking Together' by Kampus Production (CC0). 8s clip — two men in nearly-identical black suits with bow ties walk side-by-side in a wedding/event setting, with a third man (gray jacket) on the far left and a woman (patterned blouse) on the far right. Four 'person'-class objects in frame.",
+  "_lockTarget": "Lighter-haired man in black suit (3rd from left). Tests color-histogram-can't-discriminate scenario — the 4th-from-left man wears identical clothing. Hair color is the main color discriminator; faces are clearly distinct.",
+  "_caveat": "Only 198 frames at 25fps (~8s). Short for tracking dynamics but excellent for the same-clothing-different-face identity-discrimination case.",
+  "lockFrame": 0,
+  "lockBox": [0.266, 0.083, 0.430, 1.0],
+  "lockLabel": "person",
+  "analysisWidth": 640,
+  "fps": 25
+}


### PR DESCRIPTION
## Summary

Closes #62. Sources four Pexels CC0 stock videos that target person-tracking failure modes our existing fixtures didn't cover, and adds an EfficientDet-Lite2 helper for picking lock boxes without a GUI annotator.

| Test | Source | Length | Scenario | First-run result |
|---|---|---|---|---|
| `two_men_forest` | Pexels 4830416 | 17s | Two men, similar earth-tone clothing | 73% / 3 reacqs / face gate engaged |
| `two_men_suits` | Pexels 8915048 | 8s | Two men, near-identical black suits | 100% / 0 reacqs |
| `person_distance` | Pexels 5320110 | 14s | Single subject, ~6× scale change | 100% / 1 reacq |
| `crowd_street` | Pexels 12699538 | 12s | Six person detections in lock frame | 96% / 1 reacq |

## What this exercises

- **Color-histogram-can't-discriminate**: `two_men_forest` and `two_men_suits` put two similarly-clothed people in the same scene. Hair color and face are the only real discriminators — directly tests the face gate (#84) and OSNet body re-id paths.
- **Scale tolerance**: `person_distance` grows the locked subject ~6× over the clip. Gallery embeddings learned from a small initial crop have to keep matching as the subject fills the frame. The first run engaged the embedding-override path cleanly.
- **High-density same-category**: `crowd_street` has six person detections in the lock frame alone. Tests reacquisition through occlusion when many candidates pass the label gate simultaneously. Drop rate was 84% (per-frame embedding cost scales with persons in scene).

## Honest caveat

Three of the four tests probe identity (A vs B) but assert via `wrongCategoryReacqs(PERSON_LABELS)` — both subjects are 'person', so an A→B identity swap is invisible at the assertion layer. Same blind spot as `boy_indoor_wife_swap`. The reacquire metrics on these tests are still useful as a smoke test (catastrophic mistracking would push tracking rate near zero), but for true ground-truth verification we'd need per-frame-annotated labels. Tracked separately.

## Helper: `tools/synthetic_test_videos/detect_persons.py`

Runs the app's EfficientDet-Lite2 model on a still frame and prints normalized bboxes. Used to pick the `crowd_street` lock target — manual eyeballing wouldn't have produced a clean box in that scene. Generally useful for future fixture setup.

## Convention

`.mp4` files are gitignored (per existing `*.mp4` rule). JSON specs are committed; each carries `_source` URL and `_lockTarget` rationale so the fixture is reproducible — download the video from Pexels, push to `/sdcard/Android/data/com.haptictrack/files/test_videos/`, run.

## Test plan

- [x] Each test passes individually on device
- [ ] Full suite re-run after merge to confirm no interference with existing tests
- [ ] (deferred) Ground-truth annotation for two_men_*, crowd_street so A→B swaps fail loudly

🤖 Generated with [Claude Code](https://claude.com/claude-code)