### PR TITLE
Ground-truth identity validation for VideoReplayTest

### DIFF
--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -139,9 +139,20 @@ class VideoReplayTest {
         assertTrue("Should never reacquire non-person (got: ${wrong.map { "${it.label}@F${it.frame}" }})",
             wrong.isEmpty())
 
+        // Identity check: the playground often has multiple people at varying
+        // distances. Earlier runs of this test showed up to 9 reacquires —
+        // some of which could have jumped to a passing person rather than the
+        // locked subject. GT skips frames where ByteTrack itself was lost.
+        val swapped = result.wrongIdentityReacqs(iouThreshold = 0.3f)
+        assertTrue(
+            "Should never reacquire onto a different person. " +
+                "Mismatches: ${swapped.map { "frame ${it.videoFrame} box=${it.box?.toList()}" }}",
+            swapped.isEmpty()
+        )
+
         Log.i(TAG, "person_playground: trackingRate=${result.trackingRate}% " +
             "reacqs=${result.reacquisitions} losses=${result.losses} " +
-            "totalFrames=${result.totalFrames}")
+            "totalFrames=${result.totalFrames} gt=${result.groundTruth?.annotatedFrameCount ?: 0}")
     }
 
     @Test

--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -168,9 +168,21 @@ class VideoReplayTest {
         assertTrue("Should never reacquire non-person (got: ${wrong.map { "${it.label}@F${it.frame}" }})",
             wrong.isEmpty())
 
+        // Identity check via ground truth (sidecar .gt.json from
+        // tools/synthetic_test_videos/generate_ground_truth.py). Empty when
+        // GT is absent — we don't fail closed on missing ground truth, but
+        // when it exists we enforce that REACQUIRE bboxes match the lock
+        // subject's GT bbox (IoU >= 0.3) on frames where GT is confident.
+        val swapped = result.wrongIdentityReacqs(iouThreshold = 0.3f)
+        assertTrue(
+            "Should never reacquire onto a different person (son↔wife swap). " +
+                "Mismatches: ${swapped.map { "frame ${it.videoFrame} box=${it.box?.toList()}" }}",
+            swapped.isEmpty()
+        )
+
         Log.i(TAG, "boy_indoor_wife_swap: trackingRate=${result.trackingRate}% " +
             "reacqs=${result.reacquisitions} losses=${result.losses} " +
-            "totalFrames=${result.totalFrames}")
+            "totalFrames=${result.totalFrames} gt=${result.groundTruth?.annotatedFrameCount ?: 0}")
     }
 
     @Test
@@ -387,13 +399,54 @@ class VideoReplayTest {
         val frame: Int,
         val type: String,
         val objectId: Int? = null,
-        val label: String? = null
+        val label: String? = null,
+        /** Source video frame index this event occurred on (matches GT keys). */
+        val videoFrame: Int? = null,
+        /** Bbox in normalized [l,t,r,b] at event time, when available. */
+        val box: FloatArray? = null
     )
+
+    /**
+     * Per-frame ground truth: the lock subject's bbox at that source video frame,
+     * or null if ByteTrack reported the subject lost / ambiguous on that frame.
+     *
+     * Loaded from `<name>.gt.json` produced by `tools/synthetic_test_videos/
+     * generate_ground_truth.py`. Matched frames are trustworthy; we don't enforce
+     * identity on lost/ambiguous frames since GT itself is uncertain there.
+     */
+    class GroundTruth(private val byFrame: Map<Int, FloatArray>) {
+        fun boxAt(frame: Int): FloatArray? = byFrame[frame]
+        val annotatedFrameCount: Int get() = byFrame.size
+
+        companion object {
+            fun loadOrNull(file: File): GroundTruth? {
+                if (!file.exists()) return null
+                val obj = JSONObject(file.readText())
+                val anns = obj.getJSONArray("annotations")
+                val map = HashMap<Int, FloatArray>(anns.length())
+                for (i in 0 until anns.length()) {
+                    val a = anns.getJSONObject(i)
+                    val frame = a.getInt("frame")
+                    val box = a.opt("box") ?: continue
+                    if (box == JSONObject.NULL) continue
+                    val arr = box as org.json.JSONArray
+                    map[frame] = floatArrayOf(
+                        arr.getDouble(0).toFloat(),
+                        arr.getDouble(1).toFloat(),
+                        arr.getDouble(2).toFloat(),
+                        arr.getDouble(3).toFloat()
+                    )
+                }
+                return GroundTruth(map)
+            }
+        }
+    }
 
     data class ReplayResult(
         val events: List<ReplayEvent>,
         val framesTracked: Int,
-        val totalFrames: Int
+        val totalFrames: Int,
+        val groundTruth: GroundTruth? = null
     ) {
         val trackingRate: Int get() = if (totalFrames > 0) framesTracked * 100 / totalFrames else 0
         val reacquisitions: Int get() = events.count { it.type == "REACQUIRE" }
@@ -401,6 +454,36 @@ class VideoReplayTest {
         val timedOut: Boolean get() = events.any { it.type == "TIMEOUT" }
         fun wrongCategoryReacqs(validLabels: Set<String>): List<ReplayEvent> =
             events.filter { it.type == "REACQUIRE" && it.label !in validLabels }
+
+        /**
+         * REACQUIRE events whose bbox doesn't match the ground-truth subject's
+         * bbox at the same video frame (IoU below [iouThreshold]). When GT is
+         * absent for an event's frame (subject was lost/ambiguous in GT),
+         * the event is skipped — we don't enforce identity where GT itself
+         * is uncertain. Returns an empty list when no GT is loaded.
+         */
+        fun wrongIdentityReacqs(iouThreshold: Float = 0.3f): List<ReplayEvent> {
+            val gt = groundTruth ?: return emptyList()
+            return events.filter { event ->
+                if (event.type != "REACQUIRE") return@filter false
+                val frame = event.videoFrame ?: return@filter false
+                val box = event.box ?: return@filter false
+                val gtBox = gt.boxAt(frame) ?: return@filter false
+                computeIou(box, gtBox) < iouThreshold
+            }
+        }
+
+        private fun computeIou(a: FloatArray, b: FloatArray): Float {
+            val il = maxOf(a[0], b[0])
+            val it = maxOf(a[1], b[1])
+            val ir = minOf(a[2], b[2])
+            val ib = minOf(a[3], b[3])
+            if (il >= ir || it >= ib) return 0f
+            val inter = (ir - il) * (ib - it)
+            val areaA = (a[2] - a[0]) * (a[3] - a[1])
+            val areaB = (b[2] - b[0]) * (b[3] - b[1])
+            return inter / (areaA + areaB - inter)
+        }
     }
 
     /**
@@ -447,6 +530,13 @@ class VideoReplayTest {
         val analysisWidth = spec.optInt("analysisWidth", 640)
         val fps = spec.optInt("fps", 30)
         val frameDurationMs = 1000L / fps
+
+        val gtFile = File(testVideoDir, "$name.gt.json")
+        val groundTruth = GroundTruth.loadOrNull(gtFile)
+        if (groundTruth != null) {
+            Log.i(TAG, "Loaded ground truth from $gtFile " +
+                "(${groundTruth.annotatedFrameCount} annotated frames)")
+        }
 
         val ot = sharedTracker ?: error("sharedTracker not initialized — @BeforeClass failed?")
         Log.i(TAG, "Starting replay of $name")
@@ -498,14 +588,20 @@ class VideoReplayTest {
                     // Check state AFTER processing to detect transitions
                     val nowLost = ot.reacquisition.framesLost
                     val lockedObj = if (nowLost == 0 && prevLost > 0) ot.reacquisition.lockedId else null
+                    val curBox = ot.reacquisition.lastKnownBox?.let {
+                        floatArrayOf(it.left, it.top, it.right, it.bottom)
+                    }
                     when {
                         wasSearching && lockedObj != null && nowLost == 0 ->
                             events.add(ReplayEvent(framesProcessed, "REACQUIRE",
-                                lockedObj, ot.reacquisition.lastKnownLabel))
+                                lockedObj, ot.reacquisition.lastKnownLabel,
+                                videoFrame = frameIndex, box = curBox))
                         nowLost == 1 && prevLost == 0 ->
-                            events.add(ReplayEvent(framesProcessed, "LOST"))
+                            events.add(ReplayEvent(framesProcessed, "LOST",
+                                videoFrame = frameIndex))
                         ot.reacquisition.hasTimedOut && prevLost <= ot.reacquisition.maxFramesLost ->
-                            events.add(ReplayEvent(framesProcessed, "TIMEOUT"))
+                            events.add(ReplayEvent(framesProcessed, "TIMEOUT",
+                                videoFrame = frameIndex))
                     }
 
                     framesProcessed++
@@ -529,7 +625,7 @@ class VideoReplayTest {
         }
 
         val framesDropped = totalVideoFrames - framesProcessed - 1
-        val result = ReplayResult(events, framesTracked, framesProcessed)
+        val result = ReplayResult(events, framesTracked, framesProcessed, groundTruth)
         Log.i(TAG, "Replay complete: $framesProcessed processed / $totalVideoFrames total " +
             "($framesDropped dropped, ${framesDropped * 100 / totalVideoFrames.coerceAtLeast(1)}% drop rate), " +
             "${result.trackingRate}% tracked, ${result.reacquisitions} reacqs, " +

--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -226,6 +226,12 @@ class VideoReplayTest {
         assertTrue("Should never reacquire non-chair (got: ${wrong.map { "${it.label}@F${it.frame}" }})",
             wrong.isEmpty())
 
+        // GT identity check intentionally not wired here. YOLOv8 doesn't reliably
+        // detect this small white chair through camera motion (only ~14% of frames
+        // got a confident detection). Most reacquires fall in GT-null frames so
+        // the assertion would silently no-op. Revisit if we get a better tracker
+        // for static-furniture scenes.
+
         Log.i(TAG, "chair_living_room: trackingRate=${result.trackingRate}% " +
             "reacqs=${result.reacquisitions} losses=${result.losses} " +
             "totalFrames=${result.totalFrames}")
@@ -252,6 +258,13 @@ class VideoReplayTest {
         val result = replayVideo("flowerpot_wrong_reacq")
 
         assertFalse("Should not timeout", result.timedOut)
+
+        // GT identity check intentionally not wired here. YOLOv8 only confidently
+        // detects this static potted plant in ~7% of frames — empirically all 9
+        // reacquires from the first run fell in GT-null frames, so the assertion
+        // would silently skip every event. The "wrong plant" case this test was
+        // designed for would benefit from a static-object tracker (template
+        // matching, perhaps) rather than detection-based GT.
 
         Log.i(TAG, "flowerpot_wrong_reacq: trackingRate=${result.trackingRate}% " +
             "reacqs=${result.reacquisitions} losses=${result.losses} " +

--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -143,7 +143,7 @@ class VideoReplayTest {
         // distances. Earlier runs of this test showed up to 9 reacquires —
         // some of which could have jumped to a passing person rather than the
         // locked subject. GT skips frames where ByteTrack itself was lost.
-        val swapped = result.wrongIdentityReacqs(iouThreshold = 0.3f)
+        val swapped = result.wrongIdentityReacqs()
         assertTrue(
             "Should never reacquire onto a different person. " +
                 "Mismatches: ${swapped.map { "frame ${it.videoFrame} box=${it.box?.toList()}" }}",
@@ -184,7 +184,7 @@ class VideoReplayTest {
         // GT is absent — we don't fail closed on missing ground truth, but
         // when it exists we enforce that REACQUIRE bboxes match the lock
         // subject's GT bbox (IoU >= 0.3) on frames where GT is confident.
-        val swapped = result.wrongIdentityReacqs(iouThreshold = 0.3f)
+        val swapped = result.wrongIdentityReacqs()
         assertTrue(
             "Should never reacquire onto a different person (son↔wife swap). " +
                 "Mismatches: ${swapped.map { "frame ${it.videoFrame} box=${it.box?.toList()}" }}",
@@ -451,9 +451,12 @@ class VideoReplayTest {
                 for (i in 0 until anns.length()) {
                     val a = anns.getJSONObject(i)
                     val frame = a.getInt("frame")
-                    val box = a.opt("box") ?: continue
-                    if (box == JSONObject.NULL) continue
-                    val arr = box as org.json.JSONArray
+                    // optJSONArray returns null for both missing keys AND
+                    // JSONObject.NULL AND non-array types (e.g. malformed GT
+                    // file with a stray string in "box"). Skip cleanly in all
+                    // those cases instead of throwing ClassCastException.
+                    val arr = a.optJSONArray("box") ?: continue
+                    if (arr.length() < 4) continue
                     map[frame] = floatArrayOf(
                         arr.getDouble(0).toFloat(),
                         arr.getDouble(1).toFloat(),
@@ -485,8 +488,15 @@ class VideoReplayTest {
          * absent for an event's frame (subject was lost/ambiguous in GT),
          * the event is skipped — we don't enforce identity where GT itself
          * is uncertain. Returns an empty list when no GT is loaded.
+         *
+         * Default 0.5: empirically the engine's reacquire boxes overlap GT
+         * (YOLOv8) by 0.88-0.96 on correct matches, so 0.5 is well below the
+         * noise floor and catches cases where the engine landed on a clearly
+         * different subject. Tighter would risk flaking on slight detector
+         * disagreement on the same person; looser lets two adjacent persons
+         * pass when they shouldn't.
          */
-        fun wrongIdentityReacqs(iouThreshold: Float = 0.3f): List<ReplayEvent> {
+        fun wrongIdentityReacqs(iouThreshold: Float = 0.5f): List<ReplayEvent> {
             val gt = groundTruth ?: return emptyList()
             return events.filter { event ->
                 if (event.type != "REACQUIRE") return@filter false

--- a/tools/generate_ground_truth.py
+++ b/tools/generate_ground_truth.py
@@ -61,6 +61,10 @@ def main():
                         help="YOLOv8 model file (default: yolov8n.pt at repo root)")
     parser.add_argument("--score", type=float, default=0.4,
                         help="Detection confidence floor (default: 0.4)")
+    parser.add_argument("--class-name", default=None,
+                        help="COCO class name to track (default: inferred from "
+                             "spec.lockLabel). Examples: person, chair, "
+                             "potted plant, cup")
     args = parser.parse_args()
 
     video_path = Path(args.video)
@@ -85,9 +89,20 @@ def main():
     spec = json.loads(spec_path.read_text())
     lock_frame = spec["lockFrame"]
     lock_box = spec["lockBox"]
+    spec_label = spec.get("lockLabel", "person")
+    target_class = args.class_name or spec_label
 
     print(f"Loading YOLOv8: {model_path}")
     model = YOLO(model_path)
+
+    # Resolve class name -> COCO class id via the model's names map
+    name_to_id = {v: k for k, v in model.names.items()}
+    if target_class not in name_to_id:
+        print(f"Class '{target_class}' not in YOLOv8 COCO classes. "
+              f"Available: {sorted(name_to_id.keys())}", file=sys.stderr)
+        sys.exit(1)
+    target_class_id = name_to_id[target_class]
+    print(f"Tracking class '{target_class}' (id={target_class_id})")
 
     cap = cv2.VideoCapture(str(video_path))
     if not cap.isOpened():
@@ -101,11 +116,11 @@ def main():
     cap.release()
 
     # First pass — track every frame, collect (frame, track_id, box) tuples
-    # for class 0 (person in COCO). YOLO loads + tracks the whole video.
+    # for the target class.
     print("Running YOLOv8 + ByteTrack on full video...")
     tracks_per_frame = {}  # frame_idx -> list of (track_id, box_n, score)
     for frame_idx, result in enumerate(
-            model.track(source=str(video_path), classes=[0],
+            model.track(source=str(video_path), classes=[target_class_id],
                         conf=args.score, persist=True,
                         stream=True, verbose=False)):
         boxes = result.boxes

--- a/tools/generate_ground_truth.py
+++ b/tools/generate_ground_truth.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Generate ground-truth identity bboxes for a video used by VideoReplayTest.
+
+Approach: YOLOv8 person detection + ByteTrack association across frames.
+ByteTrack assigns persistent track IDs that survive brief occlusions and
+fast motion — exactly the cases that stymie pixel-template trackers
+(MIL, KCF) and naive frame-to-frame IoU matching.
+
+Why independent ground truth: YOLOv8 + ByteTrack is a different model
+family from the app's identity stack (EfficientDet + MobileNetV3 embedding
++ OSNet body re-id + ViT visual tracker). If the app's stack swaps subject
+A for subject B and YOLO+ByteTrack stays on A, the test catches it via
+VideoReplayTest.ReplayResult.wrongIdentityReacqs.
+
+Limitations: ByteTrack itself can drift on long heavy occlusions or when
+two similar subjects cross paths repeatedly. Sample preview frames in the
+generated <video>_gt_preview/ directory and manually null-out post-drift
+annotations in the .gt.json for any frames where the green GT box is on
+the wrong person — the test loader skips frames where box is null.
+
+Outputs:
+  <video>.gt.json       per-frame normalized [l,t,r,b] for the lock subject,
+                        or null when the track is absent (occluded / lost)
+  <video>_gt_preview/   sampled preview frames with the GT box overlaid
+
+Usage:
+  cd tools && .venv/bin/python generate_ground_truth.py /path/to/video.mp4
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+from ultralytics import YOLO
+
+
+def iou(a, b):
+    """IoU of two normalized [l,t,r,b] boxes."""
+    al, at, ar, ab = a
+    bl, bt, br, bb = b
+    il, it = max(al, bl), max(at, bt)
+    ir, ib = min(ar, br), min(ab, bb)
+    if il >= ir or it >= ib:
+        return 0.0
+    inter = (ir - il) * (ib - it)
+    a_area = (ar - al) * (ab - at)
+    b_area = (br - bl) * (bb - bt)
+    return inter / (a_area + b_area - inter)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("video", help="Path to .mp4")
+    parser.add_argument("--spec", help="Path to .json spec (default: <video>.json)")
+    parser.add_argument("--out", help="Path to .gt.json output")
+    parser.add_argument("--preview-every", type=int, default=30,
+                        help="Save preview frames every N frames (default: 30)")
+    parser.add_argument("--model", default="yolov8n.pt",
+                        help="YOLOv8 model file (default: yolov8n.pt at repo root)")
+    parser.add_argument("--score", type=float, default=0.4,
+                        help="Detection confidence floor (default: 0.4)")
+    args = parser.parse_args()
+
+    video_path = Path(args.video)
+    spec_path = Path(args.spec) if args.spec else video_path.with_suffix(".json")
+    out_path = Path(args.out) if args.out else \
+        video_path.with_name(video_path.stem + ".gt.json")
+    preview_dir = video_path.with_name(video_path.stem + "_gt_preview")
+    preview_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = args.model
+    if not Path(model_path).is_absolute():
+        # Try relative to script, then repo root
+        candidates = [
+            Path(__file__).parent / model_path,
+            Path(__file__).parent.parent.parent / model_path,
+        ]
+        for c in candidates:
+            if c.exists():
+                model_path = str(c)
+                break
+
+    spec = json.loads(spec_path.read_text())
+    lock_frame = spec["lockFrame"]
+    lock_box = spec["lockBox"]
+
+    print(f"Loading YOLOv8: {model_path}")
+    model = YOLO(model_path)
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        print(f"Failed to open {video_path}", file=sys.stderr)
+        sys.exit(1)
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    nframes = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    print(f"Video: {video_path.name} {w}x{h} frames={nframes}")
+    print(f"Lock frame {lock_frame}: {lock_box}")
+    cap.release()
+
+    # First pass — track every frame, collect (frame, track_id, box) tuples
+    # for class 0 (person in COCO). YOLO loads + tracks the whole video.
+    print("Running YOLOv8 + ByteTrack on full video...")
+    tracks_per_frame = {}  # frame_idx -> list of (track_id, box_n, score)
+    for frame_idx, result in enumerate(
+            model.track(source=str(video_path), classes=[0],
+                        conf=args.score, persist=True,
+                        stream=True, verbose=False)):
+        boxes = result.boxes
+        if boxes is None or boxes.id is None:
+            tracks_per_frame[frame_idx] = []
+            continue
+        ids = boxes.id.int().cpu().tolist()
+        xyxy = boxes.xyxy.cpu().tolist()
+        scores = boxes.conf.cpu().tolist()
+        items = []
+        for tid, (x1, y1, x2, y2), s in zip(ids, xyxy, scores):
+            items.append({
+                "track_id": int(tid),
+                "box": [x1 / w, y1 / h, x2 / w, y2 / h],
+                "score": float(s),
+            })
+        tracks_per_frame[frame_idx] = items
+
+    # Identify the lock track ID — the track at lock_frame whose box has
+    # highest IoU with the spec's lockBox.
+    lock_tracks = tracks_per_frame.get(lock_frame, [])
+    if not lock_tracks:
+        print(f"No tracks at lock frame {lock_frame}", file=sys.stderr)
+        sys.exit(1)
+    best_tid, best_iou = None, 0.0
+    for t in lock_tracks:
+        i = iou(t["box"], lock_box)
+        if i > best_iou:
+            best_tid, best_iou = t["track_id"], i
+    print(f"Lock track id={best_tid} (IoU={best_iou:.3f} with spec lockBox)")
+    if best_iou < 0.2:
+        print(f"WARNING: best IoU is {best_iou:.3f} — spec lockBox doesn't "
+              f"closely match any YOLO detection. Ground truth may be wrong.",
+              file=sys.stderr)
+
+    # Build annotations: for each frame, find the entry with track_id == best_tid
+    annotations = []
+    matched = lost = 0
+    cap = cv2.VideoCapture(str(video_path))
+    for frame_idx in range(nframes):
+        ret, frame = cap.read()
+        if not ret:
+            break
+        items = tracks_per_frame.get(frame_idx, [])
+        gt = None
+        for it in items:
+            if it["track_id"] == best_tid:
+                gt = it
+                break
+        if frame_idx < lock_frame:
+            annotations.append({"frame": frame_idx, "box": None, "status": "pre-lock"})
+        elif gt is None:
+            annotations.append({"frame": frame_idx, "box": None, "status": "lost"})
+            lost += 1
+        else:
+            annotations.append({
+                "frame": frame_idx,
+                "box": gt["box"],
+                "status": "matched",
+                "score": gt["score"],
+            })
+            matched += 1
+
+        # Preview
+        if frame_idx % args.preview_every == 0 and frame_idx >= lock_frame:
+            preview = frame.copy()
+            ann = annotations[-1]
+            # Draw all detected persons
+            for it in items:
+                bx = [int(it["box"][0] * w), int(it["box"][1] * h),
+                      int(it["box"][2] * w), int(it["box"][3] * h)]
+                if it["track_id"] == best_tid:
+                    color = (0, 255, 0)
+                    width = 3
+                else:
+                    color = (100, 100, 255)
+                    width = 1
+                cv2.rectangle(preview, (bx[0], bx[1]), (bx[2], bx[3]), color, width)
+                cv2.putText(preview, f"#{it['track_id']}",
+                            (bx[0], max(15, bx[1] - 5)),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1)
+            color_text = (0, 0, 255) if ann["box"] is None else (0, 255, 0)
+            cv2.putText(preview, f"f{frame_idx} GT-id={best_tid} {ann['status']}",
+                        (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, color_text, 2)
+            cv2.imwrite(str(preview_dir /
+                            f"frame_{frame_idx:05d}_{ann['status']}.jpg"), preview)
+    cap.release()
+
+    out = {
+        "video": video_path.name,
+        "method": "YOLOv8 + ByteTrack",
+        "lock_frame": lock_frame,
+        "lock_box": lock_box,
+        "lock_track_id": best_tid,
+        "lock_track_iou": best_iou,
+        "stats": {
+            "matched": matched,
+            "lost": lost,
+            "total": len(annotations),
+        },
+        "annotations": annotations,
+    }
+    out_path.write_text(json.dumps(out, indent=2))
+    print(f"Wrote {out_path}: matched={matched}, lost={lost}, total={len(annotations)}")
+    print(f"Preview frames: {preview_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_ground_truth.py
+++ b/tools/generate_ground_truth.py
@@ -76,14 +76,15 @@ def main():
 
     model_path = args.model
     if not Path(model_path).is_absolute():
-        # Try relative to script, then repo root
+        # Try CWD first, then relative-to-script, then repo root.
         candidates = [
+            Path.cwd() / model_path,
             Path(__file__).parent / model_path,
-            Path(__file__).parent.parent.parent / model_path,
+            Path(__file__).parent.parent / model_path,
         ]
         for c in candidates:
             if c.exists():
-                model_path = str(c)
+                model_path = str(c.resolve())
                 break
 
     spec = json.loads(spec_path.read_text())


### PR DESCRIPTION
## Summary

Adds an independent ground-truth pipeline so multi-person tests can detect A→B identity swaps that `wrongCategoryReacqs(PERSON_LABELS)` misses (because both subjects are 'person' to the assertion layer — the same blind spot as `boy_indoor_wife_swap`'s known bug).

## Pieces

**`tools/generate_ground_truth.py`** — YOLOv8 person detection + ByteTrack multi-object tracking on the full video. Picks the lock track at `lockFrame` by best IoU to the spec's lockBox, then follows that track ID through the rest of the video. Emits:
- `<video>.gt.json` — per-frame normalized bbox (or null when ByteTrack reports lost)
- `<video>_gt_preview/` — sampled preview frames for human visual review

**`VideoReplayTest.kt`** —
- `ReplayEvent` gains `videoFrame: Int?` + `box: FloatArray?`, captured at LOST/REACQUIRE/TIMEOUT
- `GroundTruth.loadOrNull(file)` — reads sidecar JSON if present, returns null otherwise (no-op when absent — **fail-open**)
- `ReplayResult.wrongIdentityReacqs(iouThreshold)` — for each REACQUIRE, compares its bbox to GT at that videoFrame; flags when IoU < threshold; skips frames where GT is null (don't enforce identity where GT itself is uncertain)
- `boy_indoor_wife_swap_reacquires_correctly` is the first consumer

## Why YOLOv8 + ByteTrack as ground truth

It's an entirely different model family from the app stack (EfficientDet + MobileNetV3 embedding + OSNet body re-id + ViT visual tracker). When the app stack swaps subjects and ByteTrack stays correct, GT catches it.

## Honest limitation

ByteTrack itself can drift on long heavy occlusions or repeated subject-crossings. On `boy_indoor_wife_swap` it stayed correct through frame ~1080, then swapped to the wife. Mitigated by sampling preview frames and manually trimming post-drift annotations to null — the test loader silently skips null frames.

## First run

`boy_indoor_wife_swap_reacquires_correctly` with 1094 confident GT frames (frames 1100+ trimmed):
- Test passes.
- All 6 reacquires in the GT-confident range had IoU 0.88–0.96 with GT — engine tracked the boy correctly on those frames.
- 6 post-1100 reacquires are skipped (untrusted GT). Validating those needs manual annotation or a more robust tracker.

## Test plan

- [x] `compileDebugAndroidTestKotlin` clean
- [x] `testDebugUnitTest` passes
- [x] `boy_indoor_wife_swap_reacquires_correctly` passes on device with GT loaded
- [ ] Apply to `person_playground` and other multi-person fixtures (follow-ups in this PR)
- [ ] Will conflict with PR #87 (`feat/synthetic-test-videos-62`) on `VideoReplayTest.kt`; rebase the later-merging branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)