### PR TITLE
Gallery accumulator: gate on lockSim, drop size<8 escape hatch

### DIFF
--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -121,6 +121,17 @@ class ObjectTracker(
     private var templateMismatchCount = 0
 
     /**
+     * Floor on `bestLockGallerySimilarity(emb)` for accumulating a new
+     * embedding into the gallery during VT tracking. New entries below this
+     * are drifting away from the lock identity and would poison the gallery
+     * — letting later wrong-person candidates score artificially high. Set
+     * inside the lock-gallery's own internal pairwise distribution
+     * (mean across augmentations ≈ 0.79; min ≈ 0.66) — anything substantially
+     * below that is no longer the same identity.
+     */
+    private val GALLERY_ADD_LOCK_SIM_FLOOR = 0.5f
+
+    /**
      * VT box size sanity check: the tracker's output box shouldn't grow
      * dramatically relative to the box it was initialized with. Objects don't
      * physically grow 5x in a fraction of a second — if VT is producing a
@@ -488,11 +499,27 @@ class ObjectTracker(
                             // embedding is better than no embedding for gallery diversity
                             val emb = appearanceEmbedder.embedWithFallback(bitmap, rawBox)
                             if (emb != null) {
-                                // Diversity check: only add if meaningfully different from centroid
+                                // Two-gate accumulation. Both must hold:
+                                //   1. Diverse from the existing centroid — don't add near-
+                                //      duplicates that cost RAM without adding identity coverage.
+                                //   2. Still close to the original lock identity — don't poison
+                                //      the gallery with a drifted VT crop. Without this clause
+                                //      a brief VT drift adds non-lock embeddings during the
+                                //      lock window and a later candidate matches against THOSE
+                                //      at high cosine, defeating identity discrimination.
+                                //
+                                // Old gate: `centroidSim < 0.92 OR gallery.size < 8`. The
+                                // size escape hatch forced gallery growth to 8 regardless of
+                                // identity — the structural source of the pollution. On a
+                                // diagnostic where a small distant kid was locked and the
+                                // camera panned, lockSim≈0.06 entries were waved through and
+                                // a different person scored sim=0.864 against the polluted
+                                // gallery vs 0.541 against the raw lock-only embeddings.
                                 val centroidSim = reacquisition.centroidSimilarity(emb)
-                                if (centroidSim < 0.92f || reacquisition.embeddingGallery.size < 8) {
+                                val lockSim = reacquisition.bestLockGallerySimilarity(emb)
+                                if (centroidSim < 0.92f && lockSim > GALLERY_ADD_LOCK_SIM_FLOOR) {
                                     reacquisition.addEmbedding(emb)
-                                    android.util.Log.d("AppearEmbed", "Gallery +1 → ${reacquisition.embeddingGallery.size} (centroidSim=${centroidSim})")
+                                    android.util.Log.d("AppearEmbed", "Gallery +1 → ${reacquisition.embeddingGallery.size} (centroidSim=${"%.3f".format(centroidSim)}, lockSim=${"%.3f".format(lockSim)})")
                                 }
                             }
                             // Progressive face embedding: try to capture face during tracking


### PR DESCRIPTION
## Summary
- Replaces the gallery accumulator's `centroidSim < 0.92 OR gallery.size < 8` gate with `centroidSim < 0.92 AND lockSim > GALLERY_ADD_LOCK_SIM_FLOOR (0.5)`.
- Closes the structural pollution path where brief VT drift during a short lock window adds non-lock embeddings, which then make different-person candidates score artificially high in re-acquisition.

## Why
On a live device session: lock on small distant kid → 2s pan → wife reacquired with engine-logged MNV3 `sim=0.864`. Recomputed sim from scenario.json's lock-only gallery: **0.541** max. The 0.864 came from one accumulated entry the old gate let in (`gallery.size < 8` clause). Diagnostics added under #102 showed VT-time accumulations with `lockSim ≈ 0.058 / 0.068 / 0.085` — clearly not the locked subject. Once the gallery is polluted, the engine's `bestGallerySimilarity` returns the polluted match, and the embedding override at 0.7 lets the wrong candidate bypass position/size filters.

`GALLERY_ADD_LOCK_SIM_FLOOR = 0.5` is chosen from the lock gallery's own internal pairwise distribution (mean ≈ 0.79, min ≈ 0.66). Substantially below that is no longer the same identity.

## What this is NOT
**Necessary but not sufficient.** This closes the MNV3 pollution path only. The wider re-id noise floor problem (OSNet `reId=0.6–0.7` between clearly different people, progressive face pollution after a wrong reacquire) is tracked separately in #102. Same scenario still produces wrong reacquires after this fix, just at honest "different person" sim values (≤ 0.2) rather than pollution-inflated ones.

## Test plan
- [x] 239 unit tests pass.
- [x] `man_desk_camera_swing_reacquires_correctly` and `man_desk_camera_swing_tracking_rate` pass on device — confirms legitimate gallery growth on stable subjects still works.
- [x] On the kid_to_wife reproduction (instrumentation in #102's branch), accumulations with `lockSim ≤ 0.5` are correctly rejected; subsequent wrong reacquires drop from `sim=0.864` to all `sim ≤ 0.2`.
- [ ] Run full instrumented `VideoReplayTest` suite as a broader regression check before merging.

Closes #103. Related: #102 (the wider noise-floor problem this is *not* solving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)