### PR TITLE
Re-id noise-floor diagnostics: session.log capture + OSNet gray-bias harness

### DIFF
--- a/app/src/androidTest/java/com/haptictrack/tracking/OsnetGrayBiasTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/OsnetGrayBiasTest.kt
@@ -1,0 +1,214 @@
+package com.haptictrack.tracking
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.RectF
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.random.Random
+
+/**
+ * On-device diagnostic for the hypothesis that OSNet's response to canonical
+ * inputs is dominated by the letterbox gray fill when bbox aspect mismatches
+ * its 1:2 native target. Looking for evidence that two different subjects
+ * with similar gray-padding ratios produce embeddings whose cosine similarity
+ * is biased upward by a shared "gray-canvas response" feature.
+ *
+ * Runs OSNet on a fixed grid of synthetic + extracted-crop inputs and prints
+ * a similarity matrix to logcat. No assertions — pull the logcat output to
+ * read the result.
+ */
+@RunWith(AndroidJUnit4::class)
+class OsnetGrayBiasTest {
+
+    companion object {
+        private const val TAG = "OsnetGrayBias"
+    }
+
+    private lateinit var pri: PersonReIdEmbedder
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        pri = PersonReIdEmbedder(context)
+    }
+
+    @After
+    fun teardown() {
+        pri.close()
+    }
+
+    @Test
+    fun gray_canvas_baseline_and_padding_effect() {
+        // Build inputs at OSNet's native 128×256.
+        val gray = solid(Color.rgb(127, 127, 127))
+        val black = solid(Color.BLACK)
+        val white = solid(Color.WHITE)
+        val noiseA = randomNoise(seed = 42)
+        val noiseB = randomNoise(seed = 1337)
+
+        // Two synthetic 128×256 "people" — these fill the canvas natively at OSNet's 1:2.
+        val personA = personPatch(seed = 11)
+        val personB = personPatch(seed = 22)
+        val aFull = personA
+        val bFull = personB
+
+        // Two near-square 128×128 "people" — these mimic the real-world case
+        // where a bbox aspect doesn't match OSNet's 1:2. We then test two
+        // treatments of the same square source:
+        //   1. Stretch (legacy pre-#100): resize 128×128 → 128×256, distorting vertically.
+        //   2. Canonical letterbox (#100): center at 128×128 in 128×256 with gray fill.
+        val squareA = personPatchSquare(seed = 11)
+        val squareB = personPatchSquare(seed = 22)
+        val aStretch = stretchToOsnet(squareA)
+        val bStretch = stretchToOsnet(squareB)
+        val aPad = paddedNearSquare(squareA)
+        val bPad = paddedNearSquare(squareB)
+
+        val embs = mapOf(
+            "gray"      to embed(gray),
+            "black"     to embed(black),
+            "white"     to embed(white),
+            "noiseA"    to embed(noiseA),
+            "noiseB"    to embed(noiseB),
+            "A_full"    to embed(aFull),
+            "B_full"    to embed(bFull),
+            "A_stretch" to embed(aStretch),
+            "B_stretch" to embed(bStretch),
+            "A_pad"     to embed(aPad),
+            "B_pad"     to embed(bPad),
+        ).filterValues { it != null }.mapValues { it.value!! }
+
+        Log.i(TAG, "==== OSNet response baselines ====")
+        for ((name, emb) in embs) {
+            val mean = emb.average()
+            val std = kotlin.math.sqrt(emb.sumOf { ((it - mean) * (it - mean)).toDouble() } / emb.size)
+            Log.i(TAG, "  %-8s norm=%.3f mean=%.4f std=%.4f first8=%s".format(
+                name, l2Norm(emb), mean, std,
+                emb.take(8).joinToString(",") { "%.2f".format(it) }
+            ))
+        }
+
+        Log.i(TAG, "")
+        Log.i(TAG, "==== Cosine similarity matrix ====")
+        val names = embs.keys.toList()
+        val header = "          " + names.joinToString("") { "%-8s".format(it) }
+        Log.i(TAG, header)
+        for (a in names) {
+            val row = StringBuilder("%-10s".format(a))
+            for (b in names) {
+                val sim = cosineSimilarity(embs[a]!!, embs[b]!!)
+                row.append("%-8s".format("%.3f".format(sim)))
+            }
+            Log.i(TAG, row.toString())
+        }
+
+        // Specific comparisons — what we care about for the hypothesis.
+        Log.i(TAG, "")
+        Log.i(TAG, "==== Hypothesis-directed metrics ====")
+        Log.i(TAG, "  A_full vs B_full   (different, native-aspect):    %.3f"
+            .format(cosineSimilarity(embs["A_full"]!!, embs["B_full"]!!)))
+        Log.i(TAG, "  A_stretch vs B_stretch (different, square→stretch): %.3f"
+            .format(cosineSimilarity(embs["A_stretch"]!!, embs["B_stretch"]!!)))
+        Log.i(TAG, "  A_pad  vs B_pad    (different, square→letterbox): %.3f"
+            .format(cosineSimilarity(embs["A_pad"]!!, embs["B_pad"]!!)))
+        Log.i(TAG, "  A_stretch vs A_pad (same source, stretch vs letterbox): %.3f"
+            .format(cosineSimilarity(embs["A_stretch"]!!, embs["A_pad"]!!)))
+        Log.i(TAG, "  gray   vs A_pad    (gray vs letterboxed person):  %.3f"
+            .format(cosineSimilarity(embs["gray"]!!, embs["A_pad"]!!)))
+        Log.i(TAG, "  gray   vs A_stretch (gray vs stretched person):   %.3f"
+            .format(cosineSimilarity(embs["gray"]!!, embs["A_stretch"]!!)))
+
+        // Separation = same-person sim - different-person sim. Bigger is better.
+        Log.i(TAG, "")
+        Log.i(TAG, "==== Treatment effect on separation ====")
+        Log.i(TAG, "  Stretch:   sameAvsB = -, diffAB = %.3f"
+            .format(cosineSimilarity(embs["A_stretch"]!!, embs["B_stretch"]!!)))
+        Log.i(TAG, "  Letterbox: sameAvsB = -, diffAB = %.3f  (smaller diffAB → cleaner)"
+            .format(cosineSimilarity(embs["A_pad"]!!, embs["B_pad"]!!)))
+    }
+
+    private fun embed(bmp: Bitmap): FloatArray? {
+        val canonical = CanonicalCrop(
+            bitmap = bmp,
+            sourceBoxNormalized = RectF(0f, 0f, 1f, 1f),
+            sourceCropPx = Rect(0, 0, bmp.width, bmp.height),
+            padding = Padding(0, 0, 0, 0),
+            targetWidth = 128,
+            targetHeight = 256,
+        )
+        return pri.embed(canonical)
+    }
+
+    private fun solid(color: Int): Bitmap = Bitmap.createBitmap(128, 256, Bitmap.Config.ARGB_8888).apply {
+        eraseColor(color)
+    }
+
+    private fun randomNoise(seed: Int): Bitmap {
+        val rng = Random(seed)
+        val pixels = IntArray(128 * 256) { Color.rgb(rng.nextInt(256), rng.nextInt(256), rng.nextInt(256)) }
+        return Bitmap.createBitmap(pixels, 128, 256, Bitmap.Config.ARGB_8888)
+    }
+
+    /** Synthetic full-aspect (128×256) "person-ish" patch — a colored region with structure. */
+    private fun personPatch(seed: Int): Bitmap {
+        val rng = Random(seed)
+        val bmp = Bitmap.createBitmap(128, 256, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        canvas.drawColor(Color.rgb(rng.nextInt(60, 120), rng.nextInt(60, 120), rng.nextInt(60, 120)))
+        val headColor = Color.rgb(rng.nextInt(150, 230), rng.nextInt(120, 200), rng.nextInt(100, 180))
+        val p = Paint().apply { color = headColor; isAntiAlias = true }
+        canvas.drawCircle(64f, 50f, 28f, p)
+        p.color = Color.rgb(rng.nextInt(50, 200), rng.nextInt(50, 200), rng.nextInt(50, 200))
+        canvas.drawRect(32f, 80f, 96f, 180f, p)
+        p.color = Color.rgb(rng.nextInt(40, 100), rng.nextInt(40, 100), rng.nextInt(40, 100))
+        canvas.drawRect(40f, 180f, 60f, 250f, p)
+        canvas.drawRect(68f, 180f, 88f, 250f, p)
+        return bmp
+    }
+
+    /** Synthetic near-square (128×128) "person-ish" patch — head + torso, no legs. */
+    private fun personPatchSquare(seed: Int): Bitmap {
+        val rng = Random(seed)
+        val bmp = Bitmap.createBitmap(128, 128, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        canvas.drawColor(Color.rgb(rng.nextInt(60, 120), rng.nextInt(60, 120), rng.nextInt(60, 120)))
+        val headColor = Color.rgb(rng.nextInt(150, 230), rng.nextInt(120, 200), rng.nextInt(100, 180))
+        val p = Paint().apply { color = headColor; isAntiAlias = true }
+        canvas.drawCircle(64f, 32f, 22f, p)
+        p.color = Color.rgb(rng.nextInt(50, 200), rng.nextInt(50, 200), rng.nextInt(50, 200))
+        canvas.drawRect(36f, 60f, 92f, 120f, p)
+        return bmp
+    }
+
+    /**
+     * Stretch a 128×128 source to 128×256 (legacy pre-#100 OSNet treatment of
+     * near-square bboxes — vertical 2× stretch, no aspect preservation).
+     */
+    private fun stretchToOsnet(src: Bitmap): Bitmap {
+        return Bitmap.createScaledBitmap(src, 128, 256, true)
+    }
+
+    /**
+     * Center a 128×128 source inside a 128×256 canvas with neutral-gray fill.
+     * Mimics canonical letterbox of a 1:1 bbox into OSNet's 1:2 target
+     * (≈ 50% of canvas becomes gray padding).
+     */
+    private fun paddedNearSquare(src: Bitmap): Bitmap {
+        val out = Bitmap.createBitmap(128, 256, Bitmap.Config.ARGB_8888)
+        val c = Canvas(out)
+        c.drawColor(Color.rgb(127, 127, 127))
+        val dstRect = Rect(0, 64, 128, 192)
+        val srcRect = Rect(0, 0, src.width, src.height)
+        c.drawBitmap(src, srcRect, dstRect, null)
+        return out
+    }
+}

--- a/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
+++ b/app/src/androidTest/java/com/haptictrack/tracking/VideoReplayTest.kt
@@ -294,6 +294,30 @@ class VideoReplayTest {
             result.trackingRate >= 70)
     }
 
+    /**
+     * kid_to_wife_panning: small distant kid in doorway, camera pans to wife
+     * in next room. Live-device session showed engine sim=0.864 reacquiring
+     * onto wife at frame 1 of search, but raw lock-gallery max sim is 0.541.
+     * Diagnostic test: runs the video so the augmented session.log captures
+     * ACCUM/TEMPLATE/DRIFT events during the VT lock window. Pull the log
+     * via adb to inspect the moment of accumulator firing.
+     *
+     * No assertions — when we have a hypothesis confirmed and a fix landing,
+     * tighten this into a wrongIdentityReacqs() check (boy_indoor_wife_swap
+     * does this once GT exists).
+     */
+    @Test
+    fun kid_to_wife_panning_diagnostic() {
+        val result = replayVideo("kid_to_wife_panning")
+
+        Log.i(TAG, "kid_to_wife_panning: trackingRate=${result.trackingRate}% " +
+            "reacqs=${result.reacquisitions} losses=${result.losses} " +
+            "totalFrames=${result.totalFrames}")
+
+        val firstReacq = result.events.firstOrNull { it.type == "REACQUIRE" }
+        Log.i(TAG, "kid_to_wife_panning first REACQUIRE: $firstReacq")
+    }
+
     // flowerpot_wrong_reacq: white bowl/flowerpot on table, camera zooms away and returns.
     // Black potted plant nearby. Tests that the wrong plant is NOT reacquired.
     // Regression test for: mature gallery accepting sim=0.000 candidates after timeout.

--- a/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
+++ b/app/src/main/java/com/haptictrack/tracking/ObjectTracker.kt
@@ -517,9 +517,14 @@ class ObjectTracker(
                                 // gallery vs 0.541 against the raw lock-only embeddings.
                                 val centroidSim = reacquisition.centroidSimilarity(emb)
                                 val lockSim = reacquisition.bestLockGallerySimilarity(emb)
+                                val boxStr = "%.2f,%.2f,%.2f,%.2f".format(rawBox.left, rawBox.top, rawBox.right, rawBox.bottom)
                                 if (centroidSim < 0.92f && lockSim > GALLERY_ADD_LOCK_SIM_FLOOR) {
                                     reacquisition.addEmbedding(emb)
                                     android.util.Log.d("AppearEmbed", "Gallery +1 → ${reacquisition.embeddingGallery.size} (centroidSim=${"%.3f".format(centroidSim)}, lockSim=${"%.3f".format(lockSim)})")
+                                    debugCapture.log("ACCUM +1 vtFrame=$vtConfirmedFrames gallery=${reacquisition.embeddingGallery.size} lockSim=${"%.3f".format(lockSim)} centroidSim=${"%.3f".format(centroidSim)} box=[$boxStr]")
+                                } else {
+                                    val why = if (lockSim <= GALLERY_ADD_LOCK_SIM_FLOOR) "lockSim<=$GALLERY_ADD_LOCK_SIM_FLOOR" else "centroidSim>=0.92"
+                                    debugCapture.log("ACCUM skip vtFrame=$vtConfirmedFrames gallery=${reacquisition.embeddingGallery.size} lockSim=${"%.3f".format(lockSim)} centroidSim=${"%.3f".format(centroidSim)} box=[$boxStr] ($why)")
                                 }
                             }
                             // Progressive face embedding: try to capture face during tracking
@@ -612,11 +617,13 @@ class ObjectTracker(
                                 sim < TEMPLATE_SIM_LOW -> {
                                     templateMismatchCount++
                                     android.util.Log.d("VisualTracker", "Template mismatch $templateMismatchCount/$TEMPLATE_MISMATCH_MAX (sim=${"%.3f".format(sim)})")
+                                    debugCapture.log("TEMPLATE mismatch vtFrame=$vtConfirmedFrames count=$templateMismatchCount/$TEMPLATE_MISMATCH_MAX lockSim=${"%.3f".format(sim)}")
                                 }
                                 sim > TEMPLATE_SIM_OK -> {
                                     if (templateMismatchCount > 0) {
                                         templateMismatchCount--
                                         android.util.Log.d("VisualTracker", "Template recovery $templateMismatchCount/$TEMPLATE_MISMATCH_MAX (sim=${"%.3f".format(sim)})")
+                                        debugCapture.log("TEMPLATE recovery vtFrame=$vtConfirmedFrames count=$templateMismatchCount/$TEMPLATE_MISMATCH_MAX lockSim=${"%.3f".format(sim)}")
                                     }
                                 }
                                 else -> { /* dead zone — hold the counter */ }
@@ -647,6 +654,7 @@ class ObjectTracker(
                             else -> "$vtUnconfirmedFrames unconfirmed frames (max=$adaptiveMaxUnconfirmed)"
                         }
                         android.util.Log.w("VisualTracker", "DRIFT detected — $reason (conf=${vtResult.confidence}, speed=${velocityEstimator.speed}), stopping")
+                        debugCapture.log("DRIFT vtFrame=$vtConfirmedFrames reason=\"$reason\" conf=${"%.2f".format(vtResult.confidence)} speed=${"%.3f".format(velocityEstimator.speed)}")
                         visualTracker.stop()
                         vtUnconfirmedFrames = 0
                         vtFrameCounter = 0

--- a/test_videos/kid_to_wife_panning.json
+++ b/test_videos/kid_to_wife_panning.json
@@ -1,0 +1,8 @@
+{
+  "description": "Lock on small distant kid in doorway (~9% bbox), camera pans to wife in next room. First reacquire wrongly matches wife with engine sim=0.864 vs ~0.54 max from raw lock gallery — hypothesis: gallery accumulator added a non-son embedding during the 2s VT window. Use this scenario to inspect ACCUM/TEMPLATE/DRIFT log lines in session.log.",
+  "lockFrame": 0,
+  "lockBox": [0.428, 0.340, 0.517, 0.426],
+  "lockLabel": "person",
+  "analysisWidth": 640,
+  "fps": 60
+}


### PR DESCRIPTION
## Summary
Adds the diagnostic infrastructure that surfaced the structural findings in #102. **No behavior change in production code** — purely additive instrumentation, tests, and a new replay fixture.

Branches off `feat/canonical-crop-100` because `OsnetGrayBiasTest` uses `CanonicalCrop` directly. Independent from #104 (the gallery-accumulator gate fix) — that PR carries the actual behavior change.

## What's added

**`ObjectTracker.kt`** — three new `debugCapture.log` calls so session.log captures events that previously only landed in logcat:
- `ACCUM +1` / `ACCUM skip` — gallery accumulation outcomes including a new `lockSim` diagnostic (similarity to the original 5 lock-time augmentations). Critical for seeing whether the accumulator is letting non-lock embeddings into the gallery and how far they are from the lock identity.
- `TEMPLATE mismatch` / `TEMPLATE recovery` — template self-verification transitions with frame index and lockSim.
- `DRIFT` — VT drift-detection events with reason, confidence, speed.

**`VideoReplayTest.kid_to_wife_panning_diagnostic`** — runs the new replay fixture through the full pipeline. No assertions; pull session.log post-run for forensic inspection. This was the harness that confirmed: in the failing session, the engine logged `MNV3 sim=0.864` against the wife while the lock-only gallery max was 0.541 — meaning the 6th (accumulated) gallery entry was the one matching, not the original lock. That observation drove #103.

**`OsnetGrayBiasTest`** (new) — on-device synthetic harness running OSNet's actual TFLite model:
- Pure-color baselines (gray / black / white / random noise).
- Synthetic person patches at three geometric treatments: native 1:2, square→stretch (legacy pre-#100), square→letterbox+gray (canonical post-#100).
- Prints a 9×9 cosine similarity matrix to logcat and a hypothesis-directed metrics block.

The data this harness produced is what established #102's noise-floor measurements:
| Treatment | Different-person sim | Gray correlation |
|---|---|---|
| Native 1:2 (no resize) | 0.620 | 0.514 |
| Stretch square→1:2 (legacy) | 0.667 | 0.617 |
| Letterbox square in 1:2 (canonical) | 0.686 | 0.671 |

Same-source under different treatments stays at ~0.87–0.90.

**`test_videos/kid_to_wife_panning.json`** — control file for the new replay fixture (lockBox + lockLabel from the live session). The `.mp4` is gitignored as with all test videos; contributors push it to device manually.

## Validation
- [x] 256 unit tests pass (no behavior change).
- [x] `assembleDebug` + `assembleDebugAndroidTest` clean.
- [x] `kid_to_wife_panning_diagnostic` runs in ~37s on device with rich session.log output.
- [x] `OsnetGrayBiasTest.gray_canvas_baseline_and_padding_effect` runs in ~1.4s and prints the matrix above.

## What this is NOT
- ❌ Not a fix for re-id wrong-identity reacquires. That's #102 (structural — score normalization / multi-shot / better backbone) and #103 (gallery accumulator gate).
- ❌ Not changing the production pipeline. session.log gets three new lines per relevant event; the engine itself is identical.

## Stacking note
This PR depends on #100 (PR #101) for the `CanonicalCrop` type used in `OsnetGrayBiasTest`. Merge order should be: **#101 (canonical-crop) → #104 (gate fix) → this**. After #101 merges this PR's base will move to master cleanly.

Refs #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)