### PR TITLE
Tap-to-track auto-starts recording

### DIFF
--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -163,6 +163,7 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         if (tapped != null) {
             objectTracker.lockOnObject(tapped.id, tapped.boundingBox, tapped.label)
             _uiState.update { it.copy(status = TrackingStatus.LOCKED, trackedObject = tapped) }
+            if (!_uiState.value.isRecording) toggleRecording()
         }
     }
 


### PR DESCRIPTION
## Summary

When the user taps on a detection to lock onto it, automatically start recording. Removes the second tap currently needed to start capture after locking.

One-line change in `CameraViewModel.onTapToLock`: after `lockOnObject` succeeds, if `!isRecording` toggle recording on.

## Why

Hands-free flow: tap → lock + record. The volume-down hands-free cycle (idle → lock → record) already works this way; tap-to-track was the only path that required two interactions. This makes them consistent.

## Test plan

- [ ] Tap to track an object on device → lock indicator appears AND recording starts
- [ ] Volume-down cycle still works (idle → lock+record → stop+clear)
- [ ] Tap an already-recording session re-locks without disrupting the recording
- [ ] No double-recording or lost frames at the lock moment

🤖 Generated with [Claude Code](https://claude.com/claude-code)