### PR TITLE
Fix stealth mode killing recording on exit

### DIFF
--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -269,9 +269,9 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    /** UI-only overlay; recording and pipeline are unaffected. */
     fun toggleStealthMode() {
-        val entering = !_uiState.value.stealthMode
-        _uiState.update { it.copy(stealthMode = entering) }
+        _uiState.update { it.copy(stealthMode = !it.stealthMode) }
     }
 
     /** Volume-up: toggle stealth mode. Entry/exit point for hands-free stealth. */

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -271,12 +271,7 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun toggleStealthMode() {
         val entering = !_uiState.value.stealthMode
-        if (!entering && _uiState.value.isRecording) {
-            recordingManager.stopRecording()
-        }
         _uiState.update { it.copy(stealthMode = entering) }
-        // No camera rebind needed — SurfaceTexture pipeline is always active.
-        // Stealth is purely a UI overlay change.
     }
 
     /** Volume-up: toggle stealth mode. Entry/exit point for hands-free stealth. */


### PR DESCRIPTION
## Summary
- Stealth mode (`toggleStealthMode()`) was calling `stopRecording()` when exiting stealth
- Entering stealth while recording → screen goes black → exiting stealth kills the recording
- Removed the `stopRecording` call — stealth is purely a UI overlay, no effect on recording state

## Test plan
- [ ] Start recording, enter stealth (volume-up), exit stealth — recording should continue
- [ ] Volume-down stop+clear cycle still works in stealth mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)