### PR TITLE
Haptic heartbeat: pulse-rate centering + axis hint

### DIFF
--- a/app/src/main/java/com/haptictrack/camera/CameraManager.kt
+++ b/app/src/main/java/com/haptictrack/camera/CameraManager.kt
@@ -212,7 +212,7 @@ class CameraManager(private val context: Context) {
                 onFrame = { bitmap -> onAnalysisFrame?.invoke(bitmap) },
                 onViewfinderFrame = { bitmap -> onViewfinderFrame?.invoke(bitmap) },
                 stabMatrixProvider = { gyroStabilizer.getMatrix() },
-                onRawFrame = { bitmap -> gyroStabilizer.onRawFrame(bitmap) }
+                onRawFrame = { bitmap, ts -> gyroStabilizer.onRawFrame(bitmap, ts) }
             )
             val readerSurface = reader.start()
             frameReader = reader

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -55,6 +55,9 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         // with matching -3dB cutoff: f_c = 1/(2πTC) for one pole, ≈0.187/σ for Gaussian.
         private const val FAST_SIGMA_TC_SCALE = 1.175
         private const val LOCAL_VEL_WINDOW_NS = 60_000_000L  // ±60ms for frame-local velocity
+        // Budget-aware TC: fraction of the leash budget the smoother may demand
+        // (deviation ≈ rate × TC must fit cropMargin/fEff at the current zoom).
+        private const val TC_BUDGET_SAFETY = 0.8
 
         /**
          * Per-device correction for intrinsics that don't match the HAL's actual
@@ -456,7 +459,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
                 it.println("frame_idx,timestamp_ns")
             }
             benchCorrWriter = PrintWriter(FileWriter(File(dir, "corrections.csv")), false).also {
-                it.println("frame_idx,timestamp_ns,raw_w,raw_x,raw_y,raw_z,smooth_w,smooth_x,smooth_y,smooth_z,eff_tc,corr_deg,leash,m0,m1,m2,m3,m4,m5,m6,m7,m8,zoom")
+                it.println("frame_idx,timestamp_ns,raw_w,raw_x,raw_y,raw_z,smooth_w,smooth_x,smooth_y,smooth_z,eff_tc,corr_deg,leash,m0,m1,m2,m3,m4,m5,m6,m7,m8,zoom,trans_cum_x,trans_cum_y,trans_vid_x,trans_vid_y")
             }
             PrintWriter(FileWriter(File(dir, "bench_params.csv"))).use { pw ->
                 pw.println("timeConstant,cropZoom,fxUv,fyUv,clampMarginFraction,oisCompensation")
@@ -487,11 +490,13 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         val sq = smoothedQuat
         val mat = currentMatrix.get()
         val leash = if (lastLeashActive) 1 else 0
+        val videoTrans = videoTranslationCorrection(timestampNs)
         cw.println("$frameIdx,$timestampNs," +
             "${rq.w},${rq.x},${rq.y},${rq.z}," +
             "${sq.w},${sq.x},${sq.y},${sq.z}," +
             "$effectiveTc,$lastCorrAngleDeg,$leash," +
-            "${mat[0]},${mat[1]},${mat[2]},${mat[3]},${mat[4]},${mat[5]},${mat[6]},${mat[7]},${mat[8]},$zoomRatio")
+            "${mat[0]},${mat[1]},${mat[2]},${mat[3]},${mat[4]},${mat[5]},${mat[6]},${mat[7]},${mat[8]},$zoomRatio," +
+            "$transCumX,$transCumY,${videoTrans.first},${videoTrans.second}")
     }
 
     /** Get the current stabilization matrix (column-major mat3, 9 floats). Thread-safe. */
@@ -644,14 +649,31 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         }
 
         val isPanning = highVelocityDurationSec >= PAN_ONSET_SEC
-        val zoomTcScale = sqrt(zoomRatio.toDouble().coerceAtLeast(1.0))
+
+        // Camera zoom magnifies on-screen motion: the SurfaceTexture stream is
+        // already zoom-cropped by the ISP, so its UV [0,1]² spans 1/zoom of the
+        // FOV and the same rotation displaces pixels zoom× farther. Scale the
+        // focal lengths so corrections (and the leash budget) match the stream.
+        val zoomFocal = zoomRatio.toDouble().coerceAtLeast(0.1)
+        val fxEff = fxUv * zoomFocal
+        val fyEff = fyUv * zoomFocal
+        val cropMargin = 0.5 * (1.0 - 1.0 / cropZoom)
+
+        // Budget-aware TC: the crop margin grants maxCorrAngle of correction range,
+        // and a causal smoother deviates by ~rate×TC under sustained rotation. Cap
+        // TC so the demanded deviation fits the budget — otherwise the leash chops
+        // corrections nonlinearly every sample and stabilization degrades to the
+        // margin width (measured: 26% leash duty at zoom 2.7 with the old
+        // tc×sqrt(zoom) boost, mean correction pinned at the ceiling).
+        val budgetDeg = Math.toDegrees(cropMargin / maxOf(fxEff, fyEff))
+        val tcBudget = TC_BUDGET_SAFETY * budgetDeg / smoothedAngularVelocityDeg.coerceAtLeast(1.0)
+        val cappedTc = min(timeConstant, tcBudget)
         if (adaptiveSmoothing) {
-            val baseTc = timeConstant * zoomTcScale
-            val targetTc = if (isPanning) baseTc * PAN_TC_FACTOR else baseTc
+            val targetTc = if (isPanning) cappedTc * PAN_TC_FACTOR else cappedTc
             val tcAlpha = 1.0 - exp(-dtSec * TC_RAMP_SPEED)
             effectiveTc += tcAlpha * (targetTc - effectiveTc)
         } else {
-            effectiveTc = timeConstant * zoomTcScale
+            effectiveTc = cappedTc
         }
         prevRawQuat = rawQuat
 
@@ -672,16 +694,8 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         val fastAlpha = 1.0 - exp(-(1.0 / sampleRate) / adaptFastTc)
         smoothFastQuat = slerp(smoothFastQuat, rawQuat, fastAlpha)
 
-        // Camera zoom magnifies on-screen motion: the SurfaceTexture stream is
-        // already zoom-cropped by the ISP, so its UV [0,1]² spans 1/zoom of the
-        // FOV and the same rotation displaces pixels zoom× farther. Scale the
-        // focal lengths so corrections (and the leash budget) match the stream.
-        val zoomFocal = zoomRatio.toDouble().coerceAtLeast(0.1)
-        val fxEff = fxUv * zoomFocal
-        val fyEff = fyUv * zoomFocal
-
-        // Leash: limit how far smoothed can deviate from raw.
-        val cropMargin = 0.5 * (1.0 - 1.0 / cropZoom)
+        // Leash: limit how far smoothed can deviate from raw (safety net — the
+        // budget-aware TC above should keep deviations inside the margin).
         val maxCorrAngle = cropMargin / maxOf(fxEff, fyEff)
         val devQuat = smoothedQuat.conjugate() * rawQuat
         val devAngle = 2.0 * acos(abs(devQuat.w).coerceIn(0.0, 1.0))

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -570,6 +570,15 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         rawQuat = Quat(quaternion[0].toDouble(), quaternion[1].toDouble(),
                        quaternion[2].toDouble(), quaternion[3].toDouble()).normalized()
 
+        // Quaternions double-cover rotations (q ≡ −q) and the sensor may flip sign
+        // mid-stream. Keep raw in the smoothing state's hemisphere — otherwise the
+        // leash deviation reads ~360°, fires every sample, and snaps smoothed onto
+        // raw, silently disabling stabilization (session_20260610_173942: 100% of
+        // frames latched).
+        if (initialized && rawQuat.dot(smoothedQuat) < 0.0) {
+            rawQuat = Quat(-rawQuat.w, -rawQuat.x, -rawQuat.y, -rawQuat.z)
+        }
+
         val nowNs = event.timestamp
         try { benchGyroWriter?.println("$nowNs,${rawQuat.w},${rawQuat.x},${rawQuat.y},${rawQuat.z}") } catch (_: Exception) {}
 
@@ -675,7 +684,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         val cropMargin = 0.5 * (1.0 - 1.0 / cropZoom)
         val maxCorrAngle = cropMargin / maxOf(fxEff, fyEff)
         val devQuat = smoothedQuat.conjugate() * rawQuat
-        val devAngle = 2.0 * acos(devQuat.w.coerceIn(-1.0, 1.0))
+        val devAngle = 2.0 * acos(abs(devQuat.w).coerceIn(0.0, 1.0))
         lastLeashActive = leashEnabled && devAngle > maxCorrAngle && devAngle > 1e-6
         if (lastLeashActive) {
             val catchUp = 1.0 - maxCorrAngle / devAngle
@@ -716,7 +725,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         currentMatrix.set(hPortrait)
 
         // --- Telemetry ---
-        val corrAngleDeg = 2.0 * acos(correction.w.coerceIn(-1.0, 1.0)) * (180.0 / PI)
+        val corrAngleDeg = 2.0 * acos(abs(correction.w).coerceIn(0.0, 1.0)) * (180.0 / PI)
         lastCorrAngleDeg = corrAngleDeg
 
         telFrames++
@@ -826,7 +835,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         val cropMargin = 0.5 * (1.0 - 1.0 / cropZoom)
         val maxCorrAngle = cropMargin / maxOf(fxEff, fyEff)
         val devQuat = smoothed.conjugate() * rawAtTarget
-        val devAngle = 2.0 * acos(devQuat.w.coerceIn(-1.0, 1.0))
+        val devAngle = 2.0 * acos(abs(devQuat.w).coerceIn(0.0, 1.0))
         if (leashEnabled && devAngle > maxCorrAngle && devAngle > 1e-6) {
             val catchUp = 1.0 - maxCorrAngle / devAngle
             smoothed = slerp(smoothed, rawAtTarget, catchUp)

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -218,7 +218,14 @@ class GyroStabilizer(context: Context) : SensorEventListener {
     // Translation correction: optical flow → position-domain smoothing with leash.
     // Measures post-gyro residual displacement from stabilized analysis frames,
     // smooths the cumulative path, applies the difference as a crop offset.
-    var translationCorrectionEnabled: Boolean = true
+    /**
+     * Whether the measured translation track is APPLIED as a correction. Off by
+     * default: the raw-FBO optical flow measured 7× the physically possible
+     * displacement on S26 (session 20260610_182744) and the injected correction
+     * anti-correlated with stability. Measurement + telemetry always run so
+     * EIS-off captures double as sensor-validation data.
+     */
+    var translationCorrectionEnabled: Boolean = false
         set(value) {
             if (field != value) {
                 field = value
@@ -274,7 +281,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
      * displacement to isolate the translation component.
      */
     fun onRawFrame(bitmap: android.graphics.Bitmap, frameTimestampNs: Long) {
-        if (!translationCorrectionEnabled || !_enabled) return
+        if (!_enabled) return  // measurement runs regardless of the apply flag
 
         val mat = org.opencv.core.Mat()
         val gray = org.opencv.core.Mat()

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -7,6 +7,7 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager as Camera2Manager
+import android.os.Build
 import android.util.Log
 import java.io.File
 import java.io.FileWriter
@@ -50,6 +51,17 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         private const val OIS_FAST_TC_SWAY = 0.02 // fast TC during sway — OIS handles less, let more through
         private const val OIS_ADAPT_VEL_LOW = 3.0  // °/s below which OIS handles nearly everything
         private const val OIS_ADAPT_VEL_HIGH = 15.0 // °/s above which OIS struggles with sway
+
+        /**
+         * Per-device correction for intrinsics that don't match the HAL's actual
+         * output crop. Xiaomi 13 Pro reports focal lengths 1.27× too short
+         * (bench regression eis_bench_ois_off_2 measured the uniform scale error
+         * on both axes). S26 Ultra intrinsics are genuinely calibrated (fx≠fy,
+         * FOV sanity-checks at ~72°) — applying 1.27× there over-corrects every
+         * frame by 27%. #158 tracks replacing this table with runtime auto-calibration.
+         */
+        fun empiricalFocalScale(manufacturer: String): Double =
+            if (manufacturer.equals("Xiaomi", ignoreCase = true)) 1.27 else 1.0
     }
 
     private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
@@ -466,10 +478,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
                     val fyPx = intrinsicCal[1]  // focal length in pixels (y)
                     val arrayW = activeArray.width().toDouble()
                     val arrayH = activeArray.height().toDouble()
-                    // Bench regression (eis_bench_ois_off_2) measured 1.27x uniform
-                    // scale error on both axes — HAL applies additional crop beyond
-                    // what active array dimensions describe.
-                    val empiricalScale = 1.27
+                    val empiricalScale = empiricalFocalScale(Build.MANUFACTURER)
                     fxUv = fxPx / arrayW * empiricalScale
                     fyUv = fyPx / arrayH * empiricalScale
                     Log.i(TAG, "Intrinsics (calibrated): fxPx=${"%.1f".format(fxPx)} fyPx=${"%.1f".format(fyPx)} " +
@@ -483,7 +492,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
                         val focalMm = focalLengths[0].toDouble()
                         val sensorW = sensorSize.width.toDouble()
                         val sensorH = sensorSize.height.toDouble()
-                        val empiricalScale = 1.27
+                        val empiricalScale = empiricalFocalScale(Build.MANUFACTURER)
                         fxUv = focalMm / sensorW * empiricalScale
                         fyUv = focalMm / sensorH * empiricalScale
                         Log.i(TAG, "Intrinsics (physical): focal=${"%.2f".format(focalMm)}mm " +

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -100,6 +100,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
     @Volatile private var zoomTarget: Float = 1f   // desired zoom from auto-zoom controller
     @Volatile private var zoomApplied: Float = 1f  // interpolated zoom dispatched to CameraX
     private var lastZoomDispatchNs: Long = 0L
+    private var lastZoomInterpNs: Long = 0L        // independent of EIS state (#174)
     private val ZOOM_INTERP_RATE = 25.0   // interpolation speed (~40ms TC)
     private val ZOOM_DISPATCH_NS = 16_000_000L  // CameraX dispatch throttle (~60Hz)
 
@@ -115,6 +116,31 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         zoomTarget = ratio
         zoomApplied = ratio
         zoomRatio = ratio
+    }
+
+    /**
+     * Zoom interpolation: ramp toward target at sensor rate, dispatch to CameraX at ~60Hz.
+     * Runs on every sensor sample regardless of EIS state — auto-zoom must work with
+     * stabilization off (#174). Owns its timestamp so EIS smoothing resets don't touch it.
+     */
+    internal fun interpolateZoom(nowNs: Long) {
+        val last = lastZoomInterpNs
+        lastZoomInterpNs = nowNs
+        val dtNs = nowNs - last
+        if (last == 0L || dtNs <= 0) return
+        if (dtNs > SENSOR_GAP_THRESHOLD_NS) {
+            zoomApplied = zoomTarget
+            zoomRatio = zoomApplied
+            return
+        }
+        val dtSec = dtNs / 1_000_000_000.0
+        val zoomAlpha = (1.0 - exp(-dtSec * ZOOM_INTERP_RATE)).toFloat()
+        zoomApplied += zoomAlpha * (zoomTarget - zoomApplied)
+        zoomRatio = zoomApplied
+        if (nowNs - lastZoomDispatchNs >= ZOOM_DISPATCH_NS) {
+            lastZoomDispatchNs = nowNs
+            onZoomApply?.invoke(zoomApplied)
+        }
     }
 
     /** Gaussian kernel smoothing for video frames (400ms output latency, ~95MB FBO buffer). */
@@ -541,6 +567,9 @@ class GyroStabilizer(context: Context) : SensorEventListener {
             if (historyCount < QUAT_HISTORY_SIZE) historyCount++
         }
 
+        // Zoom dispatch must run before the enabled gate — auto-zoom works with EIS off (#174)
+        interpolateZoom(nowNs)
+
         if (!enabled) {
             currentMatrix.set(IDENTITY_MATRIX.clone())
             return
@@ -567,7 +596,6 @@ class GyroStabilizer(context: Context) : SensorEventListener {
             smoothFastQuat = rawQuat
             prevRawQuat = rawQuat
             resetAdaptiveState()
-            zoomApplied = zoomTarget
             return
         }
 
@@ -660,15 +688,6 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         // onTrackingUpdate() still computes offsets for future use (VT-based center).
         val rawExcursion = maxCornerExcursion(hPortrait)
         currentMatrix.set(hPortrait)
-
-        // Zoom interpolation: ramp toward target at 200Hz, dispatch to CameraX at ~60Hz
-        val zoomAlpha = (1.0 - exp(-dtSec * ZOOM_INTERP_RATE)).toFloat()
-        zoomApplied += zoomAlpha * (zoomTarget - zoomApplied)
-        zoomRatio = zoomApplied
-        if (nowNs - lastZoomDispatchNs >= ZOOM_DISPATCH_NS) {
-            lastZoomDispatchNs = nowNs
-            onZoomApply?.invoke(zoomApplied)
-        }
 
         // --- Telemetry ---
         val corrAngleDeg = 2.0 * acos(correction.w.coerceIn(-1.0, 1.0)) * (180.0 / PI)

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -239,6 +239,16 @@ class GyroStabilizer(context: Context) : SensorEventListener {
     @Volatile private var rotOnlyUvX = 0.0   // latest rotation-only center offset (no translation)
     @Volatile private var rotOnlyUvY = 0.0
 
+    // Translation path history for the video (lookahead) path — zero-phase smoothing
+    // of the cumulative translation track, mirroring the rotation history ring.
+    private val TRANS_HISTORY_SIZE = 256  // ~8.5s at 30fps
+    private val transHistTs = LongArray(TRANS_HISTORY_SIZE)
+    private val transHistX = DoubleArray(TRANS_HISTORY_SIZE)
+    private val transHistY = DoubleArray(TRANS_HISTORY_SIZE)
+    private var transHistHead = 0
+    private var transHistCount = 0
+    private val transHistLock = Any()
+
     // Subject centering: nudge the crop toward the locked subject's bbox center.
     // Smooths the bbox center heavily to avoid detector jitter, then drifts the
     // crop offset so the subject moves toward frame center.
@@ -260,7 +270,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
      * Displacement = rotation + translation. We subtract the gyro-predicted rotation
      * displacement to isolate the translation component.
      */
-    fun onRawFrame(bitmap: android.graphics.Bitmap) {
+    fun onRawFrame(bitmap: android.graphics.Bitmap, frameTimestampNs: Long) {
         if (!translationCorrectionEnabled || !_enabled) return
 
         val mat = org.opencv.core.Mat()
@@ -331,6 +341,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
 
             transTargetUvX = (transCumX - transSmoothX).toFloat()
             transTargetUvY = (transCumY - transSmoothY).toFloat()
+            recordTranslationSample(frameTimestampNs, transCumX, transCumY)
 
             prev.release()
         } else {
@@ -838,7 +849,65 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         val correction = deviceToSensorQuat * correctionDevice * deviceToSensorQuat.conjugate()
         val r = correction.toRotationMatrix()
         val h = computeHomographyUV(r, fxEff, fyEff, cropZoom.toDouble())
-        return sensorToPortraitGL(h, sensorOrientation)
+        val hPortrait = sensorToPortraitGL(h, sensorOrientation)
+
+        // Translation correction, zero-phase: the causal path applies a lagged
+        // high-pass of the optical-flow translation track; with lookahead we
+        // subtract a symmetric Gaussian mean instead (same signs as causal path).
+        if (translationCorrectionEnabled) {
+            val (tx, ty) = videoTranslationCorrection(frameTimestampNs)
+            hPortrait[6] += tx
+            hPortrait[7] -= ty
+        }
+        return hPortrait
+    }
+
+    /** Record one optical-flow translation sample (cumulative track) for the video path. */
+    internal fun recordTranslationSample(timestampNs: Long, cumX: Double, cumY: Double) {
+        synchronized(transHistLock) {
+            transHistTs[transHistHead] = timestampNs
+            transHistX[transHistHead] = cumX
+            transHistY[transHistHead] = cumY
+            transHistHead = (transHistHead + 1) % TRANS_HISTORY_SIZE
+            if (transHistCount < TRANS_HISTORY_SIZE) transHistCount++
+        }
+    }
+
+    /**
+     * Zero-phase translation correction at the frame timestamp: cumulative track
+     * at the frame minus a Gaussian-weighted mean of the track around it.
+     * Leashed to the same margin fraction as the causal path.
+     */
+    private fun videoTranslationCorrection(frameTimestampNs: Long): Pair<Float, Float> {
+        val sigmaNs = FAST_SIGMA_TC_SCALE * TRANS_TC * 1e9
+        val windowNs = (3.0 * sigmaNs).toLong()
+        var nearIdx = -1; var nearDist = Long.MAX_VALUE
+        var sumW = 0.0; var meanX = 0.0; var meanY = 0.0
+        var cumAtFrameX = 0.0; var cumAtFrameY = 0.0
+        synchronized(transHistLock) {
+            if (transHistCount < 5) return 0f to 0f
+            for (i in 0 until transHistCount) {
+                val idx = (transHistHead - transHistCount + i + TRANS_HISTORY_SIZE) % TRANS_HISTORY_SIZE
+                val dt = transHistTs[idx] - frameTimestampNs
+                if (abs(dt) > windowNs) continue
+                val w = exp(-0.5 * (dt / sigmaNs) * (dt / sigmaNs))
+                sumW += w
+                meanX += w * transHistX[idx]
+                meanY += w * transHistY[idx]
+                if (abs(dt) < nearDist) {
+                    nearDist = abs(dt); nearIdx = idx
+                    cumAtFrameX = transHistX[idx]; cumAtFrameY = transHistY[idx]
+                }
+            }
+        }
+        // No sample close to the frame (stale history) → no correction
+        if (nearIdx < 0 || nearDist > 100_000_000L || sumW < 1e-12) return 0f to 0f
+        var tx = cumAtFrameX - meanX / sumW
+        var ty = cumAtFrameY - meanY / sumW
+        val maxCorrUv = 0.5 * (1.0 - 1.0 / cropZoom) * TRANS_MARGIN_FRAC
+        tx = tx.coerceIn(-maxCorrUv, maxCorrUv)
+        ty = ty.coerceIn(-maxCorrUv, maxCorrUv)
+        return tx.toFloat() to ty.toFloat()
     }
 
     /** Weighted quaternion average via iterative tangent-space refinement. */
@@ -1029,6 +1098,9 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         transAppliedUvX = 0f; transAppliedUvY = 0f
         prevGyroUvX = 0.0; prevGyroUvY = 0.0
         rotOnlyUvX = 0.0; rotOnlyUvY = 0.0
+        synchronized(transHistLock) {
+            transHistHead = 0; transHistCount = 0
+        }
     }
 
     private fun hfovToFocalUv(hfovDegrees: Double): Double {

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -440,7 +440,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
                 it.println("frame_idx,timestamp_ns")
             }
             benchCorrWriter = PrintWriter(FileWriter(File(dir, "corrections.csv")), false).also {
-                it.println("frame_idx,timestamp_ns,raw_w,raw_x,raw_y,raw_z,smooth_w,smooth_x,smooth_y,smooth_z,eff_tc,corr_deg,leash,m0,m1,m2,m3,m4,m5,m6,m7,m8")
+                it.println("frame_idx,timestamp_ns,raw_w,raw_x,raw_y,raw_z,smooth_w,smooth_x,smooth_y,smooth_z,eff_tc,corr_deg,leash,m0,m1,m2,m3,m4,m5,m6,m7,m8,zoom")
             }
             PrintWriter(FileWriter(File(dir, "bench_params.csv"))).use { pw ->
                 pw.println("timeConstant,cropZoom,fxUv,fyUv,clampMarginFraction,oisCompensation")
@@ -475,7 +475,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
             "${rq.w},${rq.x},${rq.y},${rq.z}," +
             "${sq.w},${sq.x},${sq.y},${sq.z}," +
             "$effectiveTc,$lastCorrAngleDeg,$leash," +
-            "${mat[0]},${mat[1]},${mat[2]},${mat[3]},${mat[4]},${mat[5]},${mat[6]},${mat[7]},${mat[8]}")
+            "${mat[0]},${mat[1]},${mat[2]},${mat[3]},${mat[4]},${mat[5]},${mat[6]},${mat[7]},${mat[8]},$zoomRatio")
     }
 
     /** Get the current stabilization matrix (column-major mat3, 9 floats). Thread-safe. */
@@ -645,9 +645,17 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         val fastAlpha = 1.0 - exp(-(1.0 / sampleRate) / adaptFastTc)
         smoothFastQuat = slerp(smoothFastQuat, rawQuat, fastAlpha)
 
+        // Camera zoom magnifies on-screen motion: the SurfaceTexture stream is
+        // already zoom-cropped by the ISP, so its UV [0,1]² spans 1/zoom of the
+        // FOV and the same rotation displaces pixels zoom× farther. Scale the
+        // focal lengths so corrections (and the leash budget) match the stream.
+        val zoomFocal = zoomRatio.toDouble().coerceAtLeast(0.1)
+        val fxEff = fxUv * zoomFocal
+        val fyEff = fyUv * zoomFocal
+
         // Leash: limit how far smoothed can deviate from raw.
         val cropMargin = 0.5 * (1.0 - 1.0 / cropZoom)
-        val maxCorrAngle = cropMargin / maxOf(fxUv, fyUv)
+        val maxCorrAngle = cropMargin / maxOf(fxEff, fyEff)
         val devQuat = smoothedQuat.conjugate() * rawQuat
         val devAngle = 2.0 * acos(devQuat.w.coerceIn(-1.0, 1.0))
         lastLeashActive = leashEnabled && devAngle > maxCorrAngle && devAngle > 1e-6
@@ -668,7 +676,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
 
         // Build homography H = K × R × K⁻¹ in UV [0,1]² space
         val r = correction.toRotationMatrix()
-        val h = computeHomographyUV(r, fxUv, fyUv, cropZoom.toDouble())
+        val h = computeHomographyUV(r, fxEff, fyEff, cropZoom.toDouble())
 
         val hPortrait = sensorToPortraitGL(h, sensorOrientation)
         // Capture rotation-only center offset BEFORE adding translation correction.

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -51,6 +51,10 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         private const val OIS_FAST_TC_SWAY = 0.02 // fast TC during sway — OIS handles less, let more through
         private const val OIS_ADAPT_VEL_LOW = 3.0  // °/s below which OIS handles nearly everything
         private const val OIS_ADAPT_VEL_HIGH = 15.0 // °/s above which OIS struggles with sway
+        // Video path: zero-phase fast reference. Maps the causal fast TC to a Gaussian σ
+        // with matching -3dB cutoff: f_c = 1/(2πTC) for one pole, ≈0.187/σ for Gaussian.
+        private const val FAST_SIGMA_TC_SCALE = 1.175
+        private const val LOCAL_VEL_WINDOW_NS = 60_000_000L  // ±60ms for frame-local velocity
 
         /**
          * Per-device correction for intrinsics that don't match the HAL's actual
@@ -191,6 +195,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
     private val historyY = DoubleArray(QUAT_HISTORY_SIZE)
     private val historyZ = DoubleArray(QUAT_HISTORY_SIZE)
     private val historyTs = LongArray(QUAT_HISTORY_SIZE)
+    private val historyZoom = FloatArray(QUAT_HISTORY_SIZE)  // zoom at sample time (video fxEff)
     private var historyHead = 0
     private var historyCount = 0
     private val historyLock = Any()
@@ -557,18 +562,20 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         val nowNs = event.timestamp
         try { benchGyroWriter?.println("$nowNs,${rawQuat.w},${rawQuat.x},${rawQuat.y},${rawQuat.z}") } catch (_: Exception) {}
 
+        // Zoom dispatch must run before the enabled gate — auto-zoom works with EIS off (#174).
+        // Before the history write so the recorded per-sample zoom is fresh.
+        interpolateZoom(nowNs)
+
         synchronized(historyLock) {
             historyW[historyHead] = rawQuat.w
             historyX[historyHead] = rawQuat.x
             historyY[historyHead] = rawQuat.y
             historyZ[historyHead] = rawQuat.z
             historyTs[historyHead] = nowNs
+            historyZoom[historyHead] = zoomRatio
             historyHead = (historyHead + 1) % QUAT_HISTORY_SIZE
             if (historyCount < QUAT_HISTORY_SIZE) historyCount++
         }
-
-        // Zoom dispatch must run before the enabled gate — auto-zoom works with EIS off (#174)
-        interpolateZoom(nowNs)
 
         if (!enabled) {
             currentMatrix.set(IDENTITY_MATRIX.clone())
@@ -794,22 +801,60 @@ class GyroStabilizer(context: Context) : SensorEventListener {
         if (window.count < 10) return getMatrix()
 
         val targetIdx = findClosestIndex(window.timestamps, window.count, frameTimestampNs)
-        val sigmaNs = GAUSSIAN_SIGMA_MS * 1_000_000.0
+        var smoothed = gaussianMeanQuat(window, frameTimestampNs, GAUSSIAN_SIGMA_MS * 1_000_000.0, targetIdx)
+        val rawAtTarget = Quat(window.w[targetIdx], window.x[targetIdx], window.y[targetIdx], window.z[targetIdx])
 
-        // Compute Gaussian weights
+        // Camera zoom at FRAME time (not "now" — zoom may have ramped during the
+        // lookahead buffer). Same geometry as the causal path: the zoom-cropped
+        // stream magnifies on-screen motion, so focal lengths scale with zoom.
+        val zoomFocal = window.zoom[targetIdx].toDouble().coerceAtLeast(0.1)
+        val fxEff = fxUv * zoomFocal
+        val fyEff = fyUv * zoomFocal
+
+        // Leash (same as causal path) — prevent corrections exceeding crop margin
+        val cropMargin = 0.5 * (1.0 - 1.0 / cropZoom)
+        val maxCorrAngle = cropMargin / maxOf(fxEff, fyEff)
+        val devQuat = smoothed.conjugate() * rawAtTarget
+        val devAngle = 2.0 * acos(devQuat.w.coerceIn(-1.0, 1.0))
+        if (leashEnabled && devAngle > maxCorrAngle && devAngle > 1e-6) {
+            val catchUp = 1.0 - maxCorrAngle / devAngle
+            smoothed = slerp(smoothed, rawAtTarget, catchUp)
+        }
+
+        // Band-split when OIS active: the fast reference must be evaluated AT the
+        // frame timestamp. The causal smoothFastQuat is ~400ms newer than the frame
+        // (lookahead buffering) — using it mixed the rotation since capture into the
+        // correction, injecting high-frequency garbage. With history on both sides of
+        // the frame we can do better than causal: a narrow symmetric Gaussian gives a
+        // ZERO-PHASE fast reference (the causal single-pole lags ~45°+ near cutoff,
+        // which made 3-8Hz corrections arrive anti-phase and amplify shake).
+        val corrRef = if (oisCompensation < 1.0) {
+            val vel = localAngVelDeg(window, targetIdx)
+            val t = ((vel - OIS_ADAPT_VEL_LOW) / (OIS_ADAPT_VEL_HIGH - OIS_ADAPT_VEL_LOW)).coerceIn(0.0, 1.0)
+            val fastTc = OIS_FAST_TC_CALM + t * (OIS_FAST_TC_SWAY - OIS_FAST_TC_CALM)
+            gaussianMeanQuat(window, frameTimestampNs, FAST_SIGMA_TC_SCALE * fastTc * 1e9, targetIdx)
+        } else rawAtTarget
+        val correctionDevice = smoothed.conjugate() * corrRef
+        val correction = deviceToSensorQuat * correctionDevice * deviceToSensorQuat.conjugate()
+        val r = correction.toRotationMatrix()
+        val h = computeHomographyUV(r, fxEff, fyEff, cropZoom.toDouble())
+        return sensorToPortraitGL(h, sensorOrientation)
+    }
+
+    /** Weighted quaternion average via iterative tangent-space refinement. */
+    private fun gaussianMeanQuat(window: QuatWindow, centerNs: Long, sigmaNs: Double, initIdx: Int): Quat {
         var weightSum = 0.0
         val weights = DoubleArray(window.count)
         for (i in 0 until window.count) {
-            val dt = (window.timestamps[i] - frameTimestampNs).toDouble()
+            val dt = (window.timestamps[i] - centerNs).toDouble()
             val w = exp(-0.5 * (dt / sigmaNs) * (dt / sigmaNs))
             weights[i] = w
             weightSum += w
         }
+        if (weightSum < 1e-12) return Quat(window.w[initIdx], window.x[initIdx], window.y[initIdx], window.z[initIdx])
         for (i in 0 until window.count) weights[i] /= weightSum
 
-        // Weighted quaternion average via iterative tangent-space refinement
-        var meanQ = Quat(window.w[targetIdx], window.x[targetIdx], window.y[targetIdx], window.z[targetIdx])
-
+        var meanQ = Quat(window.w[initIdx], window.x[initIdx], window.y[initIdx], window.z[initIdx])
         for (iter in 0..2) {
             var tx = 0.0; var ty = 0.0; var tz = 0.0
             val meanConj = meanQ.conjugate()
@@ -836,32 +881,28 @@ class GyroStabilizer(context: Context) : SensorEventListener {
                 meanQ = (meanQ * stepQ).normalized()
             }
         }
+        return meanQ
+    }
 
-        var smoothed = meanQ
-        val rawAtTarget = Quat(window.w[targetIdx], window.x[targetIdx], window.y[targetIdx], window.z[targetIdx])
-
-        // Leash (same as causal path) — prevent corrections exceeding crop margin
-        val cropMargin = 0.5 * (1.0 - 1.0 / cropZoom)
-        val maxCorrAngle = cropMargin / maxOf(fxUv, fyUv)
-        val devQuat = smoothed.conjugate() * rawAtTarget
-        val devAngle = 2.0 * acos(devQuat.w.coerceIn(-1.0, 1.0))
-        if (leashEnabled && devAngle > maxCorrAngle && devAngle > 1e-6) {
-            val catchUp = 1.0 - maxCorrAngle / devAngle
-            smoothed = slerp(smoothed, rawAtTarget, catchUp)
-        }
-
-        // Correction pipeline (same as causal path) — band-split when OIS active
-        val corrRef = if (oisCompensation < 1.0) smoothFastQuat else rawAtTarget
-        val correctionDevice = smoothed.conjugate() * corrRef
-        val correction = deviceToSensorQuat * correctionDevice * deviceToSensorQuat.conjugate()
-        val r = correction.toRotationMatrix()
-        val h = computeHomographyUV(r, fxUv, fyUv, cropZoom.toDouble())
-        return sensorToPortraitGL(h, sensorOrientation)
+    /** Angular velocity (deg/s) around a window sample, from neighbors within ±LOCAL_VEL_WINDOW_NS. */
+    private fun localAngVelDeg(window: QuatWindow, targetIdx: Int): Double {
+        val t0 = window.timestamps[targetIdx]
+        var lo = targetIdx
+        var hi = targetIdx
+        while (lo > 0 && t0 - window.timestamps[lo - 1] <= LOCAL_VEL_WINDOW_NS) lo--
+        while (hi < window.count - 1 && window.timestamps[hi + 1] - t0 <= LOCAL_VEL_WINDOW_NS) hi++
+        if (hi <= lo) return 0.0
+        val qa = Quat(window.w[lo], window.x[lo], window.y[lo], window.z[lo])
+        val qb = Quat(window.w[hi], window.x[hi], window.y[hi], window.z[hi])
+        val d = qa.conjugate() * qb
+        val angle = 2.0 * acos(abs(d.w).coerceIn(0.0, 1.0))
+        val dtSec = (window.timestamps[hi] - window.timestamps[lo]) / 1e9
+        return Math.toDegrees(angle) / dtSec
     }
 
     private data class QuatWindow(
         val w: DoubleArray, val x: DoubleArray, val y: DoubleArray, val z: DoubleArray,
-        val timestamps: LongArray, val count: Int
+        val timestamps: LongArray, val zoom: FloatArray, val count: Int
     )
 
     private fun snapshotWindow(targetNs: Long): QuatWindow? {
@@ -888,6 +929,7 @@ class GyroStabilizer(context: Context) : SensorEventListener {
                 y = DoubleArray(n) { historyY[indices[it]] },
                 z = DoubleArray(n) { historyZ[indices[it]] },
                 timestamps = LongArray(n) { historyTs[indices[it]] },
+                zoom = FloatArray(n) { historyZoom[indices[it]] },
                 count = n
             )
         }

--- a/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
+++ b/app/src/main/java/com/haptictrack/camera/GyroStabilizer.kt
@@ -69,6 +69,17 @@ class GyroStabilizer(context: Context) : SensorEventListener {
          */
         fun empiricalFocalScale(manufacturer: String): Double =
             if (manufacturer.equals("Xiaomi", ignoreCase = true)) 1.27 else 1.0
+
+        /**
+         * Gyro EIS earns its keep only where hardware stabilization is weak
+         * (Xiaomi 13 Pro: measured 2.14× improvement). On the S26 Ultra the
+         * OIS+HAL already removes 90–96% of rotational shake in every band and
+         * software EIS measured 2–2.9× WORSE than off (controlled matrix,
+         * sessions 20260610_1907xx). Default off except on known-weak devices;
+         * the UI toggle still allows manual override.
+         */
+        fun defaultEnabled(manufacturer: String): Boolean =
+            manufacturer.equals("Xiaomi", ignoreCase = true)
     }
 
     private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
@@ -156,9 +167,9 @@ class GyroStabilizer(context: Context) : SensorEventListener {
     /** Current stabilization matrix in column-major order for GL (mat3). Identity when disabled. */
     private val currentMatrix = AtomicReference(IDENTITY_MATRIX.clone())
 
-    /** Whether stabilization is active. */
+    /** Whether stabilization is active. Device-gated default — see [defaultEnabled]. */
     @Volatile
-    private var _enabled: Boolean = true
+    private var _enabled: Boolean = defaultEnabled(Build.MANUFACTURER)
     var enabled: Boolean
         get() = _enabled
         set(value) {

--- a/app/src/main/java/com/haptictrack/camera/SurfaceTextureFrameReader.kt
+++ b/app/src/main/java/com/haptictrack/camera/SurfaceTextureFrameReader.kt
@@ -48,7 +48,7 @@ class SurfaceTextureFrameReader(
     private val stabMatrixProvider: (() -> FloatArray)? = null,
     /** Called on GL thread at camera rate with a small raw (pre-stabilization) bitmap
      *  for translation displacement measurement. Bitmap is reused — do not retain. */
-    private val onRawFrame: ((Bitmap) -> Unit)? = null
+    private val onRawFrame: ((Bitmap, Long) -> Unit)? = null
 ) {
 
     companion object {
@@ -200,7 +200,7 @@ class SurfaceTextureFrameReader(
                             GLES20.glReadPixels(0, 0, rawW, rawH, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, rawBuf)
                             rawBuf.rewind()
                             rawBitmap!!.copyPixelsFromBuffer(rawBuf)
-                            onRawFrame.invoke(rawBitmap!!)
+                            onRawFrame.invoke(rawBitmap!!, st.timestamp)
                         }
 
                         // Render external texture to FBO at output resolution

--- a/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
+++ b/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
@@ -20,13 +20,13 @@ class HapticFeedbackManager(context: Context) {
     companion object {
         private const val DEAD_ZONE = 0.05f
         private const val URGENCY_RANGE = 0.45f
-        private const val INTERVAL_MIN_MS = 180f
-        private const val INTERVAL_MAX_MS = 900f
-        private const val AMP_MIN = 20f
-        private const val AMP_MAX = 180f
-        private const val PULSE_MIN_MS = 35f
-        private const val PULSE_MAX_MS = 70f
-        private const val DOUBLE_PULSE_GAP_MS = 50L
+
+        // Geiger: fastest at center, slowest at edge
+        private const val INTERVAL_CENTER_MS = 120f
+        private const val INTERVAL_EDGE_MS = 800f
+        private const val PULSE_MS = 25L
+
+        private const val DOUBLE_PULSE_GAP_MS = 45L
     }
 
     private val vibrator: Vibrator = run {
@@ -41,6 +41,9 @@ class HapticFeedbackManager(context: Context) {
     @Volatile private var driftX: Float = 0f
     @Volatile private var driftY: Float = 0f
 
+    /** Vibration amplitude 0.0–1.0. Controls how strong each click feels, not frequency. */
+    @Volatile var strength: Float = 0.5f
+
     @Synchronized
     fun updateTrackingStatus(status: TrackingStatus, driftX: Float = 0f, driftY: Float = 0f) {
         this.driftX = driftX
@@ -53,46 +56,38 @@ class HapticFeedbackManager(context: Context) {
         vibrator.cancel()
 
         when (status) {
-            TrackingStatus.LOCKED -> heartbeatJob = scope.launch { lockedHeartbeat() }
-            TrackingStatus.LOST -> heartbeatJob = scope.launch { lostHeartbeat() }
-            TrackingStatus.SEARCHING -> heartbeatJob = scope.launch { lostHeartbeat() }
+            TrackingStatus.LOCKED -> heartbeatJob = scope.launch { geigerLoop() }
+            TrackingStatus.LOST -> {}
+            TrackingStatus.SEARCHING -> {}
             TrackingStatus.IDLE -> {}
         }
     }
 
-    private suspend fun CoroutineScope.lockedHeartbeat() {
+    private suspend fun CoroutineScope.geigerLoop() {
         while (isActive) {
             val dx = abs(driftX)
             val dy = abs(driftY)
             val edgeProximity = maxOf(dx, dy).coerceIn(0f, 1f)
             val horizontalDominant = dx >= dy
 
-            val urgency = ((edgeProximity - DEAD_ZONE) / URGENCY_RANGE).coerceIn(0f, 1f)
+            // 1.0 at center, 0.0 at edge
+            val centering = 1f - ((edgeProximity - DEAD_ZONE) / URGENCY_RANGE).coerceIn(0f, 1f)
 
-            val intervalMs = lerp(INTERVAL_MAX_MS, INTERVAL_MIN_MS, urgency).toLong()
-            val amplitude = lerp(AMP_MIN, AMP_MAX, urgency).toInt().coerceIn(1, 255)
-            val pulseDuration = lerp(PULSE_MIN_MS, PULSE_MAX_MS, urgency).toLong()
+            // Geiger: fast clicks when centered, slow when drifting
+            val intervalMs = lerp(INTERVAL_EDGE_MS, INTERVAL_CENTER_MS, centering).toLong()
+            val amp = (strength * 255f).toInt().coerceIn(1, 255)
 
-            if (!horizontalDominant && urgency > 0.05f) {
-                val tapAmp = (amplitude * 0.7f).toInt().coerceIn(1, 255)
-                vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, tapAmp))
-                delay(pulseDuration + DOUBLE_PULSE_GAP_MS)
-                vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, amplitude))
-                // Subtract double-pulse overhead so total cycle matches single-pulse
-                delay(maxOf(intervalMs - pulseDuration - DOUBLE_PULSE_GAP_MS, 30L))
+            if (!horizontalDominant && centering < 0.95f) {
+                // Double click — vertical drift dominates
+                vibrator.vibrate(VibrationEffect.createOneShot(PULSE_MS, (amp * 0.7f).toInt().coerceIn(1, 255)))
+                delay(PULSE_MS + DOUBLE_PULSE_GAP_MS)
+                vibrator.vibrate(VibrationEffect.createOneShot(PULSE_MS, amp))
+                delay(maxOf(intervalMs - PULSE_MS - DOUBLE_PULSE_GAP_MS, 30L))
             } else {
-                vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, amplitude))
+                // Single click — centered or horizontal drift
+                vibrator.vibrate(VibrationEffect.createOneShot(PULSE_MS, amp))
                 delay(intervalMs)
             }
-        }
-    }
-
-    private suspend fun CoroutineScope.lostHeartbeat() {
-        while (isActive) {
-            vibrator.vibrate(VibrationEffect.createOneShot(30, 50))
-            delay(100)
-            vibrator.vibrate(VibrationEffect.createOneShot(30, 50))
-            delay(1400)
         }
     }
 

--- a/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
+++ b/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
@@ -8,24 +8,40 @@ import com.haptictrack.tracking.TrackingStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
 class HapticFeedbackManager(context: Context) {
+
+    companion object {
+        private const val DEAD_ZONE = 0.05f
+        private const val URGENCY_RANGE = 0.45f
+        private const val INTERVAL_MIN_MS = 180f
+        private const val INTERVAL_MAX_MS = 900f
+        private const val AMP_MIN = 20f
+        private const val AMP_MAX = 180f
+        private const val PULSE_MIN_MS = 35f
+        private const val PULSE_MAX_MS = 70f
+        private const val DOUBLE_PULSE_GAP_MS = 50L
+    }
 
     private val vibrator: Vibrator = run {
         val manager = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
         manager.defaultVibrator
     }
 
-    private val scope = CoroutineScope(Dispatchers.Default)
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private var heartbeatJob: Job? = null
 
     @Volatile private var currentStatus: TrackingStatus = TrackingStatus.IDLE
     @Volatile private var driftX: Float = 0f
     @Volatile private var driftY: Float = 0f
 
+    @Synchronized
     fun updateTrackingStatus(status: TrackingStatus, driftX: Float = 0f, driftY: Float = 0f) {
         this.driftX = driftX
         this.driftY = driftY
@@ -44,38 +60,35 @@ class HapticFeedbackManager(context: Context) {
         }
     }
 
-    private suspend fun lockedHeartbeat() {
-        while (true) {
+    private suspend fun CoroutineScope.lockedHeartbeat() {
+        while (isActive) {
             val dx = abs(driftX)
             val dy = abs(driftY)
             val edgeProximity = maxOf(dx, dy).coerceIn(0f, 1f)
             val horizontalDominant = dx >= dy
 
-            // Remap: 0.05 dead zone, full urgency by 0.5 (zoomed subjects fill frame)
-            val urgency = ((edgeProximity - 0.05f) / 0.45f).coerceIn(0f, 1f)
+            val urgency = ((edgeProximity - DEAD_ZONE) / URGENCY_RANGE).coerceIn(0f, 1f)
 
-            val intervalMs = lerp(900f, 180f, urgency).toLong()
-            val amplitude = lerp(20f, 180f, urgency).toInt().coerceIn(1, 255)
-            val pulseDuration = lerp(35f, 70f, urgency).toLong()
+            val intervalMs = lerp(INTERVAL_MAX_MS, INTERVAL_MIN_MS, urgency).toLong()
+            val amplitude = lerp(AMP_MIN, AMP_MAX, urgency).toInt().coerceIn(1, 255)
+            val pulseDuration = lerp(PULSE_MIN_MS, PULSE_MAX_MS, urgency).toLong()
 
             if (!horizontalDominant && urgency > 0.05f) {
-                // Double pulse — vertical drift dominates
                 val tapAmp = (amplitude * 0.7f).toInt().coerceIn(1, 255)
                 vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, tapAmp))
-                delay(pulseDuration + 60)
+                delay(pulseDuration + DOUBLE_PULSE_GAP_MS)
                 vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, amplitude))
-                delay(intervalMs)
+                // Subtract double-pulse overhead so total cycle matches single-pulse
+                delay(maxOf(intervalMs - pulseDuration - DOUBLE_PULSE_GAP_MS, 30L))
             } else {
-                // Single pulse — centered or horizontal drift
                 vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, amplitude))
                 delay(intervalMs)
             }
         }
     }
 
-    private suspend fun lostHeartbeat() {
-        while (true) {
-            // Distinct double-tap at slow rate
+    private suspend fun CoroutineScope.lostHeartbeat() {
+        while (isActive) {
             vibrator.vibrate(VibrationEffect.createOneShot(30, 50))
             delay(100)
             vibrator.vibrate(VibrationEffect.createOneShot(30, 50))
@@ -86,7 +99,7 @@ class HapticFeedbackManager(context: Context) {
     private fun lerp(a: Float, b: Float, t: Float): Float = a + (b - a) * t
 
     fun shutdown() {
-        heartbeatJob?.cancel()
+        scope.cancel()
         vibrator.cancel()
     }
 }

--- a/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
+++ b/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
@@ -5,6 +5,12 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
 import com.haptictrack.tracking.TrackingStatus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 class HapticFeedbackManager(context: Context) {
 
@@ -13,40 +19,74 @@ class HapticFeedbackManager(context: Context) {
         manager.defaultVibrator
     }
 
-    private var currentStatus: TrackingStatus? = null
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private var heartbeatJob: Job? = null
 
-    fun updateTrackingStatus(status: TrackingStatus, edgeProximity: Float = 0f) {
-        if (status == currentStatus && status != TrackingStatus.LOCKED) return
+    @Volatile private var currentStatus: TrackingStatus = TrackingStatus.IDLE
+    @Volatile private var driftX: Float = 0f
+    @Volatile private var driftY: Float = 0f
+
+    fun updateTrackingStatus(status: TrackingStatus, driftX: Float = 0f, driftY: Float = 0f) {
+        this.driftX = driftX
+        this.driftY = driftY
+
+        if (status == currentStatus) return
         currentStatus = status
 
+        heartbeatJob?.cancel()
+        vibrator.cancel()
+
         when (status) {
-            TrackingStatus.LOCKED -> vibrateLockedPulse(edgeProximity)
-            TrackingStatus.SEARCHING -> vibrateSearching()
-            TrackingStatus.LOST -> stopVibration()
-            TrackingStatus.IDLE -> stopVibration()
+            TrackingStatus.LOCKED -> heartbeatJob = scope.launch { lockedHeartbeat() }
+            TrackingStatus.LOST -> heartbeatJob = scope.launch { lostHeartbeat() }
+            TrackingStatus.SEARCHING -> heartbeatJob = scope.launch { lostHeartbeat() }
+            TrackingStatus.IDLE -> {}
         }
     }
 
-    private fun vibrateLockedPulse(edgeProximity: Float) {
-        // edgeProximity: 0.0 = centered, 1.0 = at edge of frame
-        // Subtle: gentle tick when centered, moderate nudge at edge
-        val amplitude = (20 + (edgeProximity * 80)).toInt().coerceIn(1, 100)
-        val effect = VibrationEffect.createOneShot(60, amplitude)
-        vibrator.vibrate(effect)
+    private suspend fun lockedHeartbeat() {
+        while (true) {
+            val dx = abs(driftX)
+            val dy = abs(driftY)
+            val edgeProximity = maxOf(dx, dy).coerceIn(0f, 1f)
+            val horizontalDominant = dx >= dy
+
+            // Remap: 0.05 dead zone, full urgency by 0.5 (zoomed subjects fill frame)
+            val urgency = ((edgeProximity - 0.05f) / 0.45f).coerceIn(0f, 1f)
+
+            val intervalMs = lerp(900f, 180f, urgency).toLong()
+            val amplitude = lerp(20f, 180f, urgency).toInt().coerceIn(1, 255)
+            val pulseDuration = lerp(35f, 70f, urgency).toLong()
+
+            if (!horizontalDominant && urgency > 0.05f) {
+                // Double pulse — vertical drift dominates
+                val tapAmp = (amplitude * 0.7f).toInt().coerceIn(1, 255)
+                vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, tapAmp))
+                delay(pulseDuration + 60)
+                vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, amplitude))
+                delay(intervalMs)
+            } else {
+                // Single pulse — centered or horizontal drift
+                vibrator.vibrate(VibrationEffect.createOneShot(pulseDuration, amplitude))
+                delay(intervalMs)
+            }
+        }
     }
 
-    private fun vibrateSearching() {
-        val timings = longArrayOf(0, 30, 150, 30)
-        val amplitudes = intArrayOf(0, 40, 0, 40)
-        val effect = VibrationEffect.createWaveform(timings, amplitudes, -1)
-        vibrator.vibrate(effect)
+    private suspend fun lostHeartbeat() {
+        while (true) {
+            // Distinct double-tap at slow rate
+            vibrator.vibrate(VibrationEffect.createOneShot(30, 50))
+            delay(100)
+            vibrator.vibrate(VibrationEffect.createOneShot(30, 50))
+            delay(1400)
+        }
     }
 
-    private fun stopVibration() {
-        vibrator.cancel()
-    }
+    private fun lerp(a: Float, b: Float, t: Float): Float = a + (b - a) * t
 
     fun shutdown() {
+        heartbeatJob?.cancel()
         vibrator.cancel()
     }
 }

--- a/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
+++ b/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
@@ -65,26 +65,28 @@ class HapticFeedbackManager(context: Context) {
 
     private suspend fun CoroutineScope.geigerLoop() {
         while (isActive) {
+            val currentStrength = strength
+            if (currentStrength <= 0f) {
+                delay(100L)
+                continue
+            }
+
             val dx = abs(driftX)
             val dy = abs(driftY)
             val edgeProximity = maxOf(dx, dy).coerceIn(0f, 1f)
             val horizontalDominant = dx >= dy
 
-            // 1.0 at center, 0.0 at edge
             val centering = 1f - ((edgeProximity - DEAD_ZONE) / URGENCY_RANGE).coerceIn(0f, 1f)
 
-            // Geiger: fast clicks when centered, slow when drifting
             val intervalMs = lerp(INTERVAL_EDGE_MS, INTERVAL_CENTER_MS, centering).toLong()
-            val amp = (strength * 255f).toInt().coerceIn(1, 255)
+            val amp = (currentStrength * 255f).toInt().coerceIn(1, 255)
 
             if (!horizontalDominant && centering < 0.95f) {
-                // Double click — vertical drift dominates
                 vibrator.vibrate(VibrationEffect.createOneShot(PULSE_MS, (amp * 0.7f).toInt().coerceIn(1, 255)))
                 delay(PULSE_MS + DOUBLE_PULSE_GAP_MS)
                 vibrator.vibrate(VibrationEffect.createOneShot(PULSE_MS, amp))
-                delay(maxOf(intervalMs - PULSE_MS - DOUBLE_PULSE_GAP_MS, 30L))
+                delay(maxOf(intervalMs - PULSE_MS * 2 - DOUBLE_PULSE_GAP_MS, 30L))
             } else {
-                // Single click — centered or horizontal drift
                 vibrator.vibrate(VibrationEffect.createOneShot(PULSE_MS, amp))
                 delay(intervalMs)
             }

--- a/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
+++ b/app/src/main/java/com/haptictrack/haptics/HapticFeedbackManager.kt
@@ -21,12 +21,13 @@ class HapticFeedbackManager(context: Context) {
         private const val DEAD_ZONE = 0.05f
         private const val URGENCY_RANGE = 0.45f
 
-        // Geiger: fastest at center, slowest at edge
         private const val INTERVAL_CENTER_MS = 120f
         private const val INTERVAL_EDGE_MS = 800f
         private const val PULSE_MS = 25L
 
         private const val DOUBLE_PULSE_GAP_MS = 45L
+
+        private const val LOST_GRACE_MS = 800L
     }
 
     private val vibrator: Vibrator = run {
@@ -36,6 +37,7 @@ class HapticFeedbackManager(context: Context) {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private var heartbeatJob: Job? = null
+    private var graceJob: Job? = null
 
     @Volatile private var currentStatus: TrackingStatus = TrackingStatus.IDLE
     @Volatile private var driftX: Float = 0f
@@ -52,14 +54,25 @@ class HapticFeedbackManager(context: Context) {
         if (status == currentStatus) return
         currentStatus = status
 
-        heartbeatJob?.cancel()
-        vibrator.cancel()
+        graceJob?.cancel()
 
         when (status) {
-            TrackingStatus.LOCKED -> heartbeatJob = scope.launch { geigerLoop() }
-            TrackingStatus.LOST -> {}
-            TrackingStatus.SEARCHING -> {}
-            TrackingStatus.IDLE -> {}
+            TrackingStatus.LOCKED -> {
+                if (heartbeatJob?.isActive != true) {
+                    heartbeatJob = scope.launch { geigerLoop() }
+                }
+            }
+            TrackingStatus.LOST, TrackingStatus.SEARCHING -> {
+                graceJob = scope.launch {
+                    delay(LOST_GRACE_MS)
+                    heartbeatJob?.cancel()
+                    vibrator.cancel()
+                }
+            }
+            TrackingStatus.IDLE -> {
+                heartbeatJob?.cancel()
+                vibrator.cancel()
+            }
         }
     }
 

--- a/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
+++ b/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
@@ -101,5 +101,7 @@ data class TrackingUiState(
     /** Optical-flow translation correction on top of gyro rotation EIS. */
     val translationEis: Boolean = true,
     /** Which object categories to show and allow tracking. */
-    val trackingFilter: TrackingFilter = TrackingFilter.ALL
+    val trackingFilter: TrackingFilter = TrackingFilter.ALL,
+    /** Haptic vibration strength 0.0–1.0. */
+    val hapticStrength: Float = 0.5f
 )

--- a/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
+++ b/app/src/main/java/com/haptictrack/tracking/TrackingState.kt
@@ -99,7 +99,7 @@ data class TrackingUiState(
     /** OIS compensation active (scale correction to avoid overcorrecting). */
     val oisCompensation: Boolean = true,
     /** Optical-flow translation correction on top of gyro rotation EIS. */
-    val translationEis: Boolean = true,
+    val translationEis: Boolean = false,
     /** Which object categories to show and allow tracking. */
     val trackingFilter: TrackingFilter = TrackingFilter.ALL,
     /** Haptic vibration strength 0.0–1.0. */

--- a/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraScreen.kt
@@ -404,6 +404,7 @@ fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
                         onToggleTranslation = { viewModel.toggleTranslationEis() },
                         onToggleLeash = { viewModel.toggleLeash() },
                         onToggleOis = { viewModel.toggleOisCompensation() },
+                        onHapticStrengthChange = { viewModel.setHapticStrength(it) },
                         onDismiss = { showDebugSheet = false }
                     )
                 }
@@ -919,6 +920,7 @@ private fun DebugBottomSheet(
     onToggleTranslation: () -> Unit,
     onToggleLeash: () -> Unit,
     onToggleOis: () -> Unit,
+    onHapticStrengthChange: (Float) -> Unit,
     onDismiss: () -> Unit
 ) {
     ModalBottomSheet(
@@ -980,6 +982,48 @@ private fun DebugBottomSheet(
                 SettingRow("Translation Correction", uiState.translationEis, onToggleTranslation)
                 SettingRow("Leash", uiState.leashEnabled, onToggleLeash)
                 SettingRow("OIS Compensation", uiState.oisCompensation, onToggleOis)
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = "HAPTICS",
+                color = Color.White.copy(alpha = 0.4f),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.5.sp,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Strength",
+                    color = Color.White,
+                    fontSize = 14.sp,
+                    modifier = Modifier.weight(0.35f)
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(0.65f)
+                ) {
+                    Text("Off", color = Color.White.copy(alpha = 0.35f), fontSize = 11.sp)
+                    Slider(
+                        value = uiState.hapticStrength,
+                        onValueChange = onHapticStrengthChange,
+                        modifier = Modifier.weight(1f).height(32.dp),
+                        colors = SliderDefaults.colors(
+                            thumbColor = Color.White,
+                            activeTrackColor = Color.White.copy(alpha = 0.5f),
+                            inactiveTrackColor = Color.White.copy(alpha = 0.12f)
+                        )
+                    )
+                    Text("Max", color = Color.White.copy(alpha = 0.35f), fontSize = 11.sp)
+                }
             }
         }
     }

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -273,6 +273,12 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         toggleRecording()
     }
 
+    fun setHapticStrength(strength: Float) {
+        val clamped = strength.coerceIn(0f, 1f)
+        hapticManager.strength = clamped
+        _uiState.update { it.copy(hapticStrength = clamped) }
+    }
+
     fun cycleTrackingFilter() {
         val next = when (_uiState.value.trackingFilter) {
             TrackingFilter.ALL -> TrackingFilter.PERSON_ONLY
@@ -368,7 +374,7 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
         zoomController.reset()
         hapticManager.updateTrackingStatus(TrackingStatus.IDLE)
         _uiState.update {
-            TrackingUiState(status = TrackingStatus.IDLE, isRecording = false, captureMode = it.captureMode, stealthMode = it.stealthMode, isReady = it.isReady, ispStabilization = it.ispStabilization, gyroEis = it.gyroEis, gyroStrength = it.gyroStrength, adaptiveEis = it.adaptiveEis, leashEnabled = it.leashEnabled, oisCompensation = it.oisCompensation, translationEis = it.translationEis, trackingFilter = it.trackingFilter)
+            TrackingUiState(status = TrackingStatus.IDLE, isRecording = false, captureMode = it.captureMode, stealthMode = it.stealthMode, isReady = it.isReady, ispStabilization = it.ispStabilization, gyroEis = it.gyroEis, gyroStrength = it.gyroStrength, adaptiveEis = it.adaptiveEis, leashEnabled = it.leashEnabled, oisCompensation = it.oisCompensation, translationEis = it.translationEis, trackingFilter = it.trackingFilter, hapticStrength = it.hapticStrength)
         }
     }
 

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -87,8 +87,11 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
                     else -> TrackingStatus.SEARCHING
                 }
 
-                val edgeProximity = lockedObject?.let {
-                    zoomController.calculateEdgeProximity(it.boundingBox)
+                val driftX = lockedObject?.let {
+                    (it.boundingBox.centerX() - 0.5f) * 2f
+                } ?: 0f
+                val driftY = lockedObject?.let {
+                    (it.boundingBox.centerY() - 0.5f) * 2f
                 } ?: 0f
 
                 val targetZoom = if (lockedObject != null) {
@@ -113,7 +116,7 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
                     ).also { cameraManager.setZoomTarget(it) }
                 } else null
 
-                hapticManager.updateTrackingStatus(status, edgeProximity)
+                hapticManager.updateTrackingStatus(status, driftX, driftY)
 
                 val displayObjects = if (status == TrackingStatus.IDLE) {
                     smoothIdleDetections(allObjects)

--- a/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
+++ b/app/src/main/java/com/haptictrack/ui/CameraViewModel.kt
@@ -64,6 +64,9 @@ class CameraViewModel(application: Application) : AndroidViewModel(application) 
     init {
         orientationListener.start()
         setGyroStrength(_uiState.value.gyroStrength)
+        // Gyro EIS default is device-gated (off on S26 — hardware OIS wins);
+        // sync the UI toggle to the stabilizer's actual state.
+        _uiState.update { it.copy(gyroEis = cameraManager.gyroStabilizer.enabled) }
 
         // Load ML models on background thread — takes ~20s with GPU delegate init
         viewModelScope.launch(Dispatchers.Default) {

--- a/app/src/test/java/com/haptictrack/camera/GyroBudgetTcTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroBudgetTcTest.kt
@@ -1,0 +1,79 @@
+package com.haptictrack.camera
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowSensor
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+/**
+ * The crop margin grants a fixed correction budget in view UV; at zoom Z the
+ * angular budget shrinks by 1/Z while a causal smoother demands deviation
+ * ~ angular-rate x TC. Session 20260610_175612 ran with mean correction (2.15 deg)
+ * riding the budget ceiling (2.66 deg at zoom 2.72) and the leash clamping 26% of
+ * frames — smoothing demanded ~5x more than physics allowed. The effective TC must
+ * be capped so the demanded deviation fits the budget WITHOUT the leash chopping it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GyroBudgetTcTest {
+
+    private val sensor: Sensor = ShadowSensor.newInstance(Sensor.TYPE_GAME_ROTATION_VECTOR)
+
+    private fun event(x: Float, y: Float, z: Float, w: Float, tNs: Long): SensorEvent {
+        val e = ReflectionHelpers.callConstructor(
+            SensorEvent::class.java,
+            ClassParameter.from(Int::class.javaPrimitiveType, 4)
+        )
+        e.values[0] = x; e.values[1] = y; e.values[2] = z; e.values[3] = w
+        e.sensor = sensor
+        e.timestamp = tNs
+        return e
+    }
+
+    @Test
+    fun `correction stays within crop margin at zoom without the leash`() {
+        // 20 deg/s sustained rotation at 3x zoom for 1s, leash OFF: only the
+        // budget-aware TC can keep the correction inside the crop margin.
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stab.adaptiveSmoothing = false
+        stab.leashEnabled = false
+        stab.setZoomImmediate(3f)
+
+        var t = 1_000_000_000L
+        var angleDeg = 0.0
+        while (t <= 2_000_000_000L) {
+            val half = Math.toRadians(angleDeg / 2.0)
+            stab.onSensorChanged(event(sin(half).toFloat(), 0f, 0f, cos(half).toFloat(), t))
+            angleDeg += 0.1  // 0.1 deg per 5ms = 20 deg/s
+            t += 5_000_000L
+        }
+        val m = stab.getMatrix()
+
+        val base = GyroStabilizer(RuntimeEnvironment.getApplication())
+        base.adaptiveSmoothing = false
+        base.leashEnabled = false
+        base.setZoomImmediate(3f)
+        t = 1_000_000_000L
+        while (t <= 2_000_000_000L) {
+            base.onSensorChanged(event(0f, 0f, 0f, 1f, t))
+            t += 5_000_000L
+        }
+        val b = base.getMatrix()
+
+        val corr = hypot((m[6] - b[6]).toDouble(), (m[7] - b[7]).toDouble())
+        val cropMargin = 0.5 * (1.0 - 1.0 / 1.3)  // 0.1154 UV at default cropZoom
+        assertTrue(
+            "correction $corr UV must fit the crop margin $cropMargin via TC capping (leash disabled)",
+            corr < cropMargin * 1.15
+        )
+        assertTrue("correction should be substantial, not zero (got $corr)", corr > 0.02)
+    }
+}

--- a/app/src/test/java/com/haptictrack/camera/GyroBudgetTcTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroBudgetTcTest.kt
@@ -42,7 +42,7 @@ class GyroBudgetTcTest {
     fun `correction stays within crop margin at zoom without the leash`() {
         // 20 deg/s sustained rotation at 3x zoom for 1s, leash OFF: only the
         // budget-aware TC can keep the correction inside the crop margin.
-        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         stab.adaptiveSmoothing = false
         stab.leashEnabled = false
         stab.setZoomImmediate(3f)
@@ -57,7 +57,7 @@ class GyroBudgetTcTest {
         }
         val m = stab.getMatrix()
 
-        val base = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val base = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         base.adaptiveSmoothing = false
         base.leashEnabled = false
         base.setZoomImmediate(3f)

--- a/app/src/test/java/com/haptictrack/camera/GyroHemisphereTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroHemisphereTest.kt
@@ -40,7 +40,7 @@ class GyroHemisphereTest {
     /** Identity then sustained tilt, with every quat multiplied by [sign]. */
     private fun correctionTranslation(sign: Float): Double {
         fun run(halfAngle: Float): FloatArray {
-            val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+            val stab = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
             stab.adaptiveSmoothing = false
             var t = 1_000_000_000L
             while (t <= 1_100_000_000L) {
@@ -68,7 +68,7 @@ class GyroHemisphereTest {
     @Test
     fun `mid-stream hemisphere flip does not latch the leash`() {
         // Same orientation stream, but the sensor flips quat sign halfway through.
-        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         stab.adaptiveSmoothing = false
         var t = 1_000_000_000L
         while (t <= 1_100_000_000L) {
@@ -79,7 +79,7 @@ class GyroHemisphereTest {
         }
         val m = stab.getMatrix()
 
-        val ref = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val ref = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         ref.adaptiveSmoothing = false
         t = 1_000_000_000L
         while (t <= 1_100_000_000L) {

--- a/app/src/test/java/com/haptictrack/camera/GyroHemisphereTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroHemisphereTest.kt
@@ -1,0 +1,96 @@
+package com.haptictrack.camera
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowSensor
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+/**
+ * Quaternions double-cover rotations: q and −q are the same orientation, and the
+ * sensor may deliver either sign. Session 20260610_173942 spent 100% of its frames
+ * with dot(smoothed, raw) < 0 — the leash deviation read ~360°, fired every sample,
+ * and snapped smoothed onto raw: stabilization silently off for the whole session.
+ * Corrections must be identical regardless of the incoming hemisphere.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GyroHemisphereTest {
+
+    private val sensor: Sensor = ShadowSensor.newInstance(Sensor.TYPE_GAME_ROTATION_VECTOR)
+
+    private fun event(x: Float, y: Float, z: Float, w: Float, tNs: Long): SensorEvent {
+        val e = ReflectionHelpers.callConstructor(
+            SensorEvent::class.java,
+            ClassParameter.from(Int::class.javaPrimitiveType, 4)
+        )
+        e.values[0] = x; e.values[1] = y; e.values[2] = z; e.values[3] = w
+        e.sensor = sensor
+        e.timestamp = tNs
+        return e
+    }
+
+    /** Identity then sustained tilt, with every quat multiplied by [sign]. */
+    private fun correctionTranslation(sign: Float): Double {
+        fun run(halfAngle: Float): FloatArray {
+            val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+            stab.adaptiveSmoothing = false
+            var t = 1_000_000_000L
+            while (t <= 1_100_000_000L) {
+                stab.onSensorChanged(event(0f, 0f, 0f, sign * 1f, t)); t += 5_000_000L
+            }
+            while (t <= 1_300_000_000L) {
+                stab.onSensorChanged(event(sign * sin(halfAngle), 0f, 0f, sign * cos(halfAngle), t))
+                t += 5_000_000L
+            }
+            return stab.getMatrix()
+        }
+        val m = run(0.01f)
+        val base = run(0f)
+        return hypot((m[6] - base[6]).toDouble(), (m[7] - base[7]).toDouble())
+    }
+
+    @Test
+    fun `corrections are identical for both quaternion hemispheres`() {
+        val pos = correctionTranslation(sign = +1f)
+        val neg = correctionTranslation(sign = -1f)
+        assertTrue("expected nonzero correction, got $pos", pos > 1e-5)
+        assertEquals("negative-hemisphere quats must produce the same correction", pos, neg, pos * 0.02)
+    }
+
+    @Test
+    fun `mid-stream hemisphere flip does not latch the leash`() {
+        // Same orientation stream, but the sensor flips quat sign halfway through.
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stab.adaptiveSmoothing = false
+        var t = 1_000_000_000L
+        while (t <= 1_100_000_000L) {
+            stab.onSensorChanged(event(0f, 0f, 0f, 1f, t)); t += 5_000_000L
+        }
+        while (t <= 1_300_000_000L) {  // identical rotation, negated representation
+            stab.onSensorChanged(event(-sin(0.01f), 0f, 0f, -cos(0.01f), t)); t += 5_000_000L
+        }
+        val m = stab.getMatrix()
+
+        val ref = GyroStabilizer(RuntimeEnvironment.getApplication())
+        ref.adaptiveSmoothing = false
+        t = 1_000_000_000L
+        while (t <= 1_100_000_000L) {
+            ref.onSensorChanged(event(0f, 0f, 0f, 1f, t)); t += 5_000_000L
+        }
+        while (t <= 1_300_000_000L) {
+            ref.onSensorChanged(event(sin(0.01f), 0f, 0f, cos(0.01f), t)); t += 5_000_000L
+        }
+        val r = ref.getMatrix()
+
+        assertEquals("flip mid-stream must not change the correction (m6)", r[6], m[6], 1e-4f)
+        assertEquals("flip mid-stream must not change the correction (m7)", r[7], m[7], 1e-4f)
+    }
+}

--- a/app/src/test/java/com/haptictrack/camera/GyroStabilizerTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroStabilizerTest.kt
@@ -84,4 +84,13 @@ class GyroStabilizerTest {
         assertEquals(0.0, m[1], 1e-6)
         assertEquals(1.0, m[4], 1e-6)
     }
+
+    @Test
+    fun `empirical focal scale applies 1_27 on Xiaomi only`() {
+        assertEquals(1.27, GyroStabilizer.empiricalFocalScale("Xiaomi"), 1e-9)
+        assertEquals(1.27, GyroStabilizer.empiricalFocalScale("xiaomi"), 1e-9)
+        assertEquals(1.0, GyroStabilizer.empiricalFocalScale("samsung"), 1e-9)
+        assertEquals(1.0, GyroStabilizer.empiricalFocalScale("Google"), 1e-9)
+        assertEquals(1.0, GyroStabilizer.empiricalFocalScale(""), 1e-9)
+    }
 }

--- a/app/src/test/java/com/haptictrack/camera/GyroStabilizerTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroStabilizerTest.kt
@@ -93,4 +93,13 @@ class GyroStabilizerTest {
         assertEquals(1.0, GyroStabilizer.empiricalFocalScale("Google"), 1e-9)
         assertEquals(1.0, GyroStabilizer.empiricalFocalScale(""), 1e-9)
     }
+
+    @Test
+    fun `gyro EIS default is on for Xiaomi only`() {
+        assertTrue(GyroStabilizer.defaultEnabled("Xiaomi"))
+        assertTrue(GyroStabilizer.defaultEnabled("xiaomi"))
+        assertFalse(GyroStabilizer.defaultEnabled("samsung"))
+        assertFalse(GyroStabilizer.defaultEnabled("Google"))
+        assertFalse(GyroStabilizer.defaultEnabled(""))
+    }
 }

--- a/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
@@ -1,0 +1,108 @@
+package com.haptictrack.camera
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowSensor
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+/**
+ * getVideoMatrix (lookahead video path) must mirror the causal path's geometry:
+ *  - corrections scale with the camera zoom ratio (the stream is zoom-cropped)
+ *  - the OIS-split fast reference is evaluated AT the frame timestamp, not "now".
+ *    Frames render ~400ms after capture; using the causal smoothFastQuat mixed
+ *    a 400ms-newer orientation into the correction, injecting garbage rotation.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GyroVideoMatrixTest {
+
+    private val sensor: Sensor = ShadowSensor.newInstance(Sensor.TYPE_GAME_ROTATION_VECTOR)
+
+    private fun event(x: Float, y: Float, z: Float, w: Float, tNs: Long): SensorEvent {
+        val e = ReflectionHelpers.callConstructor(
+            SensorEvent::class.java,
+            ClassParameter.from(Int::class.javaPrimitiveType, 4)
+        )
+        e.values[0] = x; e.values[1] = y; e.values[2] = z; e.values[3] = w
+        e.sensor = sensor
+        e.timestamp = tNs
+        return e
+    }
+
+    private fun feedIdentity(stab: GyroStabilizer, fromNs: Long, toNs: Long, stepNs: Long): Long {
+        var t = fromNs
+        while (t <= toNs) {
+            stab.onSensorChanged(event(0f, 0f, 0f, 1f, t))
+            t += stepNs
+        }
+        return t
+    }
+
+    private fun feedTilt(stab: GyroStabilizer, halfAngle: Float, fromNs: Long, toNs: Long, stepNs: Long) {
+        var t = fromNs
+        while (t <= toNs) {
+            stab.onSensorChanged(event(sin(halfAngle), 0f, 0f, cos(halfAngle), t))
+            t += stepNs
+        }
+    }
+
+    /** History: identity then sustained tilt; frame at the end. Returns video matrix. */
+    private fun videoMatrix(zoom: Float, halfAngle: Float): FloatArray {
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stab.adaptiveSmoothing = false
+        stab.setZoomImmediate(zoom)
+        val step = 5_000_000L
+        feedIdentity(stab, 1_000_000_000L, 1_100_000_000L, step)
+        feedTilt(stab, halfAngle, 1_105_000_000L, 1_200_000_000L, step)
+        return stab.getVideoMatrix(1_200_000_000L)
+    }
+
+    @Test
+    fun `video correction translation scales with camera zoom`() {
+        fun corr(zoom: Float): Double {
+            val m = videoMatrix(zoom, halfAngle = 0.01f)
+            val base = videoMatrix(zoom, halfAngle = 0f)
+            return hypot((m[6] - base[6]).toDouble(), (m[7] - base[7]).toDouble())
+        }
+        val t1 = corr(1f)
+        val t3 = corr(3f)
+        assertTrue("expected nonzero video correction at 1x, got $t1", t1 > 1e-5)
+        assertEquals("video correction must scale ~3x at 3x zoom", 3.0, t3 / t1, 0.15)
+    }
+
+    @Test
+    fun `fast reference ignores rotation that happens after the frame`() {
+        // OIS split active. The device is still through the frame epoch, then a
+        // quick rotation happens 550ms AFTER the frame (i.e. between capture and
+        // lookahead render). The correction for the frame must not contain it.
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stab.adaptiveSmoothing = false
+        stab.oisCompensation = 0.4
+        val step = 5_000_000L
+        feedIdentity(stab, 1_000_000_000L, 1_750_000_000L, step)
+        feedTilt(stab, halfAngle = 0.15f, fromNs = 1_755_000_000L, toNs = 1_800_000_000L, stepNs = step)
+
+        val frameTs = 1_200_000_000L
+        val m = stab.getVideoMatrix(frameTs)
+
+        // Baseline: identical timeline with no rotation at all → pure static crop.
+        val stabBase = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stabBase.adaptiveSmoothing = false
+        stabBase.oisCompensation = 0.4
+        feedIdentity(stabBase, 1_000_000_000L, 1_800_000_000L, step)
+        val base = stabBase.getVideoMatrix(frameTs)
+
+        val corr = hypot((m[6] - base[6]).toDouble(), (m[7] - base[7]).toDouble())
+        // Old behavior: corrRef = causal smoothFastQuat ≈ 0.3 rad rotated → corr ≈ 0.15 UV.
+        // New behavior: zero-phase reference at the frame time ≈ identity → corr ≈ 0.
+        assertTrue("correction for a still frame must not include future rotation (got $corr UV)", corr < 0.03)
+    }
+}

--- a/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
@@ -56,7 +56,7 @@ class GyroVideoMatrixTest {
 
     /** History: identity then sustained tilt; frame at the end. Returns video matrix. */
     private fun videoMatrix(zoom: Float, halfAngle: Float): FloatArray {
-        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         stab.adaptiveSmoothing = false
         stab.setZoomImmediate(zoom)
         val step = 5_000_000L
@@ -83,7 +83,7 @@ class GyroVideoMatrixTest {
         // OIS split active. The device is still through the frame epoch, then a
         // quick rotation happens 550ms AFTER the frame (i.e. between capture and
         // lookahead render). The correction for the frame must not contain it.
-        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         stab.adaptiveSmoothing = false
         stab.oisCompensation = 0.4
         val step = 5_000_000L
@@ -94,7 +94,7 @@ class GyroVideoMatrixTest {
         val m = stab.getVideoMatrix(frameTs)
 
         // Baseline: identical timeline with no rotation at all → pure static crop.
-        val stabBase = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val stabBase = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         stabBase.adaptiveSmoothing = false
         stabBase.oisCompensation = 0.4
         feedIdentity(stabBase, 1_000_000_000L, 1_800_000_000L, step)
@@ -108,7 +108,7 @@ class GyroVideoMatrixTest {
 
     /** Translation samples: cumX oscillates at 5Hz, cumY constant. Quats stay identity. */
     private fun translationOffsets(cumXAt: (Double) -> Double): Pair<Float, Float> {
-        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         stab.adaptiveSmoothing = false
         stab.translationCorrectionEnabled = true  // apply is off by default (unvalidated sensor)
         feedIdentity(stab, 1_000_000_000L, 1_800_000_000L, 5_000_000L)
@@ -119,7 +119,7 @@ class GyroVideoMatrixTest {
             t += 25_000_000L  // 40fps so a sample lands exactly on the frame timestamp
         }
         val m = stab.getVideoMatrix(1_450_000_000L)
-        val base = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val base = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         base.adaptiveSmoothing = false
         feedIdentity(base, 1_000_000_000L, 1_800_000_000L, 5_000_000L)
         val b = base.getVideoMatrix(1_450_000_000L)

--- a/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
@@ -110,6 +110,7 @@ class GyroVideoMatrixTest {
     private fun translationOffsets(cumXAt: (Double) -> Double): Pair<Float, Float> {
         val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
         stab.adaptiveSmoothing = false
+        stab.translationCorrectionEnabled = true  // apply is off by default (unvalidated sensor)
         feedIdentity(stab, 1_000_000_000L, 1_800_000_000L, 5_000_000L)
         var t = 1_000_000_000L
         while (t <= 1_800_000_000L) {

--- a/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroVideoMatrixTest.kt
@@ -105,4 +105,40 @@ class GyroVideoMatrixTest {
         // New behavior: zero-phase reference at the frame time ≈ identity → corr ≈ 0.
         assertTrue("correction for a still frame must not include future rotation (got $corr UV)", corr < 0.03)
     }
+
+    /** Translation samples: cumX oscillates at 5Hz, cumY constant. Quats stay identity. */
+    private fun translationOffsets(cumXAt: (Double) -> Double): Pair<Float, Float> {
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stab.adaptiveSmoothing = false
+        feedIdentity(stab, 1_000_000_000L, 1_800_000_000L, 5_000_000L)
+        var t = 1_000_000_000L
+        while (t <= 1_800_000_000L) {
+            val sec = (t - 1_000_000_000L) / 1e9
+            stab.recordTranslationSample(t, cumXAt(sec), 0.0)
+            t += 25_000_000L  // 40fps so a sample lands exactly on the frame timestamp
+        }
+        val m = stab.getVideoMatrix(1_450_000_000L)
+        val base = GyroStabilizer(RuntimeEnvironment.getApplication())
+        base.adaptiveSmoothing = false
+        feedIdentity(base, 1_000_000_000L, 1_800_000_000L, 5_000_000L)
+        val b = base.getVideoMatrix(1_450_000_000L)
+        return (m[6] - b[6]) to (m[7] - b[7])
+    }
+
+    @Test
+    fun `video translation correction cancels oscillation at the frame time`() {
+        // 5Hz hand-shake translation, frame at a positive peak (t=0.45s → sin=1).
+        val amp = 0.02
+        val (dx, _) = translationOffsets { sec -> amp * kotlin.math.sin(2 * Math.PI * 5.0 * sec) }
+        // Zero-phase mean over the symmetric window ≈ 0 → correction ≈ +amp on m6.
+        assertEquals("translation correction must offset the frame by ~the shake amplitude",
+            amp, dx.toDouble(), 0.005)
+    }
+
+    @Test
+    fun `video translation correction rejects constant offset`() {
+        val (dx, dy) = translationOffsets { 0.015 }
+        assertEquals(0.0, dx.toDouble(), 1e-4)
+        assertEquals(0.0, dy.toDouble(), 1e-4)
+    }
 }

--- a/app/src/test/java/com/haptictrack/camera/GyroZoomDispatchTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroZoomDispatchTest.kt
@@ -1,0 +1,81 @@
+package com.haptictrack.camera
+
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Zoom interpolation must run independently of the EIS enabled state (#174).
+ * Before the fix, zoom dispatch lived below the `if (!enabled) return` in
+ * onSensorChanged — auto-zoom targets were silently dropped with EIS off.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GyroZoomDispatchTest {
+
+    private fun stabilizer(enabled: Boolean): GyroStabilizer {
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stab.enabled = enabled
+        return stab
+    }
+
+    @Test
+    fun `zoom dispatches when EIS is disabled`() {
+        val stab = stabilizer(enabled = false)
+        var dispatched = -1f
+        stab.onZoomApply = { dispatched = it }
+        stab.setZoomTarget(5f)
+
+        stab.interpolateZoom(1_000_000_000L)  // first sample — records timestamp only
+        stab.interpolateZoom(1_020_000_000L)  // 20ms later — interpolates + dispatches
+
+        assertTrue("expected a zoom dispatch, got none", dispatched > 0f)
+        assertTrue("zoom should ramp toward target, got $dispatched", dispatched > 1f && dispatched < 5f)
+    }
+
+    @Test
+    fun `zoom converges to target over repeated samples`() {
+        val stab = stabilizer(enabled = false)
+        var dispatched = -1f
+        stab.onZoomApply = { dispatched = it }
+        stab.setZoomTarget(4f)
+
+        var t = 1_000_000_000L
+        repeat(200) {  // 200 samples at 5ms = 1s of sensor time
+            stab.interpolateZoom(t)
+            t += 5_000_000L
+        }
+        assertEquals(4f, dispatched, 0.05f)
+    }
+
+    @Test
+    fun `long sensor gap snaps zoom without interpolating stale dt`() {
+        val stab = stabilizer(enabled = false)
+        var dispatched = -1f
+        stab.onZoomApply = { dispatched = it }
+        stab.setZoomTarget(3f)
+
+        stab.interpolateZoom(1_000_000_000L)
+        stab.interpolateZoom(2_000_000_000L)  // 1s gap > threshold — snap, no dispatch
+
+        assertEquals(-1f, dispatched, 0f)     // gap path doesn't dispatch
+        stab.interpolateZoom(2_020_000_000L)  // next regular sample dispatches the snapped value
+        assertEquals(3f, dispatched, 0.01f)
+    }
+
+    @Test
+    fun `dispatch is throttled below 16ms`() {
+        val stab = stabilizer(enabled = false)
+        var dispatchCount = 0
+        stab.onZoomApply = { dispatchCount++ }
+        stab.setZoomTarget(2f)
+
+        stab.interpolateZoom(1_000_000_000L)
+        stab.interpolateZoom(1_020_000_000L)  // dispatch #1
+        stab.interpolateZoom(1_025_000_000L)  // 5ms later — throttled
+        stab.interpolateZoom(1_030_000_000L)  // 10ms later — throttled
+
+        assertEquals(1, dispatchCount)
+    }
+}

--- a/app/src/test/java/com/haptictrack/camera/GyroZoomFocalTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroZoomFocalTest.kt
@@ -1,0 +1,76 @@
+package com.haptictrack.camera
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowSensor
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+/**
+ * EIS corrections must scale with the camera zoom ratio. The SurfaceTexture
+ * stream is already zoom-cropped by the ISP, so its UV [0,1]² spans 1/zoom of
+ * the FOV — the same rotation displaces pixels zoom× farther in view UV.
+ * Before the fix, the homography used the unzoomed focal length, making
+ * corrections zoom× too small (3x zoom → corrections at 1/3 strength).
+ */
+@RunWith(RobolectricTestRunner::class)
+class GyroZoomFocalTest {
+
+    private val sensor: Sensor = ShadowSensor.newInstance(Sensor.TYPE_GAME_ROTATION_VECTOR)
+
+    private fun event(x: Float, y: Float, z: Float, w: Float, tNs: Long): SensorEvent {
+        val e = ReflectionHelpers.callConstructor(
+            SensorEvent::class.java,
+            ClassParameter.from(Int::class.javaPrimitiveType, 4)
+        )
+        e.values[0] = x; e.values[1] = y; e.values[2] = z; e.values[3] = w
+        e.sensor = sensor
+        e.timestamp = tNs
+        return e
+    }
+
+    private fun matrixAfter(zoom: Float, halfAngle: Float): FloatArray {
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        stab.adaptiveSmoothing = false
+        stab.setZoomImmediate(zoom)
+        stab.onSensorChanged(event(0f, 0f, 0f, 1f, 1_000_000_000L))
+        stab.onSensorChanged(event(sin(halfAngle), 0f, 0f, cos(halfAngle), 1_005_000_000L))
+        return stab.getMatrix()
+    }
+
+    /**
+     * Feed identity then a small tilt about device X; return correction translation
+     * relative to the no-rotation baseline (the affine carries a constant
+     * crop-centering offset in m[6]/m[7] that must be subtracted).
+     */
+    private fun correctionTranslation(zoom: Float): Double {
+        val m = matrixAfter(zoom, halfAngle = 0.01f)  // 0.02 rad tilt
+        val base = matrixAfter(zoom, halfAngle = 0f)
+        return hypot((m[6] - base[6]).toDouble(), (m[7] - base[7]).toDouble())
+    }
+
+    @Test
+    fun `correction translation scales with camera zoom`() {
+        val t1 = correctionTranslation(zoom = 1f)
+        val t3 = correctionTranslation(zoom = 3f)
+        assertTrue("expected nonzero correction at 1x, got $t1", t1 > 1e-5)
+        assertEquals("correction must scale ~3x at 3x zoom", 3.0, t3 / t1, 0.15)
+    }
+
+    @Test
+    fun `zoom at 1x leaves correction unchanged`() {
+        // Two independent runs at 1x must produce identical corrections —
+        // guards against the zoom factor leaking state between samples.
+        val a = correctionTranslation(zoom = 1f)
+        val b = correctionTranslation(zoom = 1f)
+        assertEquals(a, b, 1e-12)
+    }
+}

--- a/app/src/test/java/com/haptictrack/camera/GyroZoomFocalTest.kt
+++ b/app/src/test/java/com/haptictrack/camera/GyroZoomFocalTest.kt
@@ -38,7 +38,7 @@ class GyroZoomFocalTest {
     }
 
     private fun matrixAfter(zoom: Float, halfAngle: Float): FloatArray {
-        val stab = GyroStabilizer(RuntimeEnvironment.getApplication())
+        val stab = GyroStabilizer(RuntimeEnvironment.getApplication()).apply { enabled = true }
         stab.adaptiveSmoothing = false
         stab.setZoomImmediate(zoom)
         stab.onSensorChanged(event(0f, 0f, 0f, 1f, 1_000_000_000L))

--- a/tools/eis_matrix.py
+++ b/tools/eis_matrix.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Phase 1 experiment-matrix evaluator.
+
+Roles (same scene, ~20s each):
+  A braced,   EIS off  -> noise floor
+  B braced,   EIS on   -> injection test       PASS: residual <= 1.1x A per band
+  C handheld, EIS off, 1x    -> OIS transfer (what EIS must handle)
+  D handheld, EIS off, zoom  -> OIS transfer at zoom
+  E handheld, EIS on,  1x    -> end-to-end     PASS: residual <= 0.4x C in 1-8Hz
+  F handheld, EIS on,  zoom  -> end-to-end     PASS: residual <= 0.4x D in 1-8Hz
+
+Usage:
+  .venv/bin/python eis_matrix.py A=<session_dir> B=<dir> C=<dir> D=<dir> E=<dir> F=<dir>
+Any subset of roles is allowed; comparisons print only when both sides exist.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from eis_progress import BANDS, ANALYSIS_H, gyro_input, video_residual, telemetry
+
+
+def fmt_bands(d, fmt="{:.2f}"):
+    return "  ".join(f"{b[0]}-{b[1]}Hz=" + fmt.format(d[b]) for b in BANDS)
+
+
+def main():
+    sessions = {}
+    for arg in sys.argv[1:]:
+        role, _, path = arg.partition("=")
+        sessions[role.upper()] = Path(path)
+
+    data = {}
+    for role, path in sorted(sessions.items()):
+        videos = sorted(path.glob("*.mp4"))
+        if not videos:
+            print(f"{role}: no video in {path}, skipping")
+            continue
+        gin, gin_rms = gyro_input(path)
+        vres, vres_rms, good, total, fps = video_residual(videos[0])
+        tel = telemetry(path)
+        data[role] = dict(gin=gin, gin_rms=gin_rms, vres=vres, vres_rms=vres_rms, tel=tel, fps=fps)
+        zoom = tel.get("zoom_med", 1.0)
+        print(f"[{role}] {path.name}: shake {gin_rms:.1f} deg/s, residual RMS {vres_rms:.2f}px, "
+              f"zoom {zoom:.2f}, leash {tel.get('leash_pct', 0):.0f}%")
+        print(f"     residual bands: {fmt_bands(vres)}")
+
+    print()
+    if "A" in data and "B" in data:
+        print("INJECTION TEST (B vs A, braced — does EIS add motion?):")
+        ok = True
+        for b in BANDS:
+            ratio = data["B"]["vres"][b] / max(data["A"]["vres"][b], 1e-9)
+            flag = "OK" if ratio <= 1.1 else "FAIL"
+            ok &= flag == "OK"
+            print(f"  {b[0]}-{b[1]}Hz: {ratio:.2f}x {flag}")
+        print(f"  => {'PASS' if ok else 'FAIL'}")
+        print()
+
+    for role, label in (("C", "1x"), ("D", "zoom")):
+        if role not in data:
+            continue
+        d = data[role]
+        zoom = d["tel"].get("zoom_med", 1.0)
+        fx_uv = 0.685
+        pred = {b: np.radians(d["gin"][b]) / d["fps"] * fx_uv * zoom * ANALYSIS_H for b in BANDS}
+        surv = {b: d["vres"][b] / max(pred[b], 1e-9) for b in BANDS}
+        print(f"OIS TRANSFER ({role}, handheld EIS-off {label}): fraction of gyro-predicted "
+              f"rotation surviving to screen (the band EIS must handle):")
+        print(f"  {fmt_bands(surv)}")
+        print()
+
+    for on, off, label in (("E", "C", "1x"), ("F", "D", "zoom")):
+        if on not in data or off not in data:
+            continue
+        # normalize by shake input: takes differ, so compare suppression not raw residual
+        print(f"END-TO-END ({on} vs {off}, {label}): residual ratio per band, "
+              f"shake-normalized (x{data[off]['gin_rms'] / data[on]['gin_rms']:.2f}):")
+        norm = data[off]["gin_rms"] / max(data[on]["gin_rms"], 1e-9)
+        ok = True
+        for b in BANDS:
+            ratio = (data[on]["vres"][b] * norm) / max(data[off]["vres"][b], 1e-9)
+            target = 0.4 if b[0] >= 1 and b[1] <= 8 else None
+            flag = "" if target is None else (" OK" if ratio <= target else " FAIL")
+            if target is not None:
+                ok &= ratio <= target
+            print(f"  {b[0]}-{b[1]}Hz: {ratio:.2f}x{flag}")
+        print(f"  => 1-8Hz target <=0.40: {'PASS' if ok else 'FAIL'}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/eis_progress.py
+++ b/tools/eis_progress.py
@@ -96,6 +96,14 @@ def telemetry(session: Path):
     if "zoom" in rows[0]:
         zooms = [float(r["zoom"]) for r in rows]
         out["zoom_med"] = float(np.median(zooms))
+    if "trans_vid_x" in rows[0]:
+        tvx = np.array([float(r["trans_vid_x"]) for r in rows])
+        tvy = np.array([float(r["trans_vid_y"]) for r in rows])
+        out["trans_vid_rms_uv"] = float(np.sqrt(np.mean(tvx**2 + tvy**2)))
+        cx = np.array([float(r["trans_cum_x"]) for r in rows])
+        cy = np.array([float(r["trans_cum_y"]) for r in rows])
+        dc = np.hypot(np.diff(cx), np.diff(cy))
+        out["trans_flow_rms_uv"] = float(np.sqrt(np.mean(dc**2)))
     return out
 
 
@@ -133,6 +141,9 @@ def main():
     if tel:
         print(f"  telemetry: zoom_med={zoom:.2f} leash={tel.get('leash_pct', 0):.0f}% "
               f"corr_mean={tel.get('corr_deg_mean', 0):.2f}deg  phase-corr good {good}/{total}")
+        if "trans_vid_rms_uv" in tel:
+            print(f"  translation: optical-flow step RMS={tel['trans_flow_rms_uv']:.5f} UV/frame, "
+                  f"video correction RMS={tel['trans_vid_rms_uv']:.5f} UV")
 
     ledger = args.ledger or session.parent / "eis_progress.csv"
     new = not ledger.exists()

--- a/tools/eis_progress.py
+++ b/tools/eis_progress.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""EIS progress scorecard — empirical, per-session, build-comparable.
+
+Measures (a) hand-shake input from gyro_raw.csv, (b) residual on-screen
+jitter from the recorded video via phase correlation, and reports per-band
+suppression (output/input). Appends one row per session to a ledger CSV so
+stabilization progress across builds is a table, not a gut feeling.
+
+Protocol for comparable numbers: same scene, same approximate distance and
+zoom, ~20s handheld hold, EIS on. Run:
+    .venv/bin/python eis_progress.py ../bench_data/s26_eis/session_<ts> [--label "build/desc"]
+"""
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+BANDS = [(0.2, 1), (1, 3), (3, 8), (8, 15)]
+ANALYSIS_H, ANALYSIS_W = 480, 270  # portrait 4K downscale
+
+
+def band_rms(sig, fs):
+    sig = np.asarray(sig, dtype=np.float64)
+    sig = sig - sig.mean()
+    f = np.fft.rfftfreq(len(sig), 1 / fs)
+    p = np.abs(np.fft.rfft(sig)) ** 2 / len(sig)
+    return {b: float(np.sqrt(p[(f >= b[0]) & (f < b[1])].sum())) for b in BANDS}
+
+
+def gyro_input(session: Path):
+    """Per-band angular-rate shake (deg-equivalent displacement per frame at 30fps)."""
+    g = np.loadtxt(session / "gyro_raw.csv", delimiter=",", skiprows=1)
+    t = (g[:, 0] - g[0, 0]) / 1e9
+    q = g[:, 1:5]
+    dots = np.abs(np.sum(q[1:] * q[:-1], axis=1)).clip(0, 1)
+    dang = np.degrees(2 * np.arccos(dots))
+    dt = np.diff(t)
+    ok = dt > 1e-6
+    w = dang[ok] / dt[ok]
+    fs = 1 / np.median(dt)
+    tu = np.arange(t[0], t[-1], 1 / fs)
+    wu = np.interp(tu, t[1:][ok], w)
+    return band_rms(wu, fs), float(np.sqrt(np.mean(wu**2)))
+
+
+def video_residual(video: Path, max_frames=1200):
+    """Per-band residual jitter (px at 480p) from phase correlation, response-gated."""
+    cap = cv2.VideoCapture(str(video))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    hann = None
+    prev = None
+    disp = []
+    n = 0
+    while n < max_frames:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        gray = cv2.resize(gray, (ANALYSIS_W, ANALYSIS_H)).astype(np.float32)
+        crop = gray[60:420, 35:235]
+        if hann is None:
+            hann = cv2.createHanningWindow((crop.shape[1], crop.shape[0]), cv2.CV_32F)
+        crop = crop * hann
+        if prev is not None:
+            (du, dv), resp = cv2.phaseCorrelate(prev, crop)
+            disp.append((du, dv, resp))
+        prev = crop
+        n += 1
+    cap.release()
+    d = np.array(disp)
+    good = d[:, 2] > max(0.05, np.percentile(d[:, 2], 20))
+    du, dv = d[:, 0].copy(), d[:, 1].copy()
+    du[~good] = 0.0
+    dv[~good] = 0.0
+    mag = np.hypot(du, dv)
+    bu, bv = band_rms(du, fps), band_rms(dv, fps)
+    bands = {b: float(np.hypot(bu[b], bv[b])) for b in BANDS}
+    return bands, float(np.sqrt(np.mean(mag**2))), int(good.sum()), len(d), fps
+
+
+def telemetry(session: Path):
+    f = session / "corrections.csv"
+    if not f.exists():
+        return {}
+    rows = list(csv.DictReader(open(f)))
+    if not rows:
+        return {}
+    out = {
+        "frames": len(rows),
+        "leash_pct": 100.0 * sum(int(r["leash"]) for r in rows) / len(rows),
+        "corr_deg_mean": float(np.mean([float(r["corr_deg"]) for r in rows])),
+    }
+    if "zoom" in rows[0]:
+        zooms = [float(r["zoom"]) for r in rows]
+        out["zoom_med"] = float(np.median(zooms))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("session", type=Path)
+    ap.add_argument("--label", default="")
+    ap.add_argument("--ledger", type=Path, default=None)
+    args = ap.parse_args()
+
+    session = args.session
+    videos = sorted(session.glob("*.mp4"))
+    if not videos:
+        sys.exit(f"no .mp4 in {session}")
+    video = videos[0]
+
+    gin, gin_rms = gyro_input(session)
+    vres, vres_rms, good, total, fps = video_residual(video)
+    tel = telemetry(session)
+    zoom = tel.get("zoom_med", 1.0)
+
+    # Suppression: residual px normalized by gyro-predicted px for the same band.
+    # predicted px/frame ~ rad/s * (1/fps) * fx_uv * zoom * frame_height
+    fx_uv = 0.685
+    pred = {b: np.radians(gin[b]) / fps * fx_uv * zoom * ANALYSIS_H for b in BANDS}
+    supp = {b: (vres[b] / pred[b] if pred[b] > 1e-9 else float("nan")) for b in BANDS}
+
+    print(f"session: {session.name}  label: {args.label or '-'}")
+    print(f"  input shake (gyro): RMS {gin_rms:.1f} deg/s | bands "
+          + " ".join(f"{b[0]}-{b[1]}Hz={gin[b]:.2f}" for b in BANDS))
+    print(f"  residual (video):   RMS {vres_rms:.2f} px@480p | bands "
+          + " ".join(f"{b[0]}-{b[1]}Hz={vres[b]:.2f}" for b in BANDS))
+    print(f"  residual/input ratio per band (lower=better, >1 = motion beyond gyro [translation]):")
+    print("    " + "  ".join(f"{b[0]}-{b[1]}Hz={supp[b]:.2f}" for b in BANDS))
+    if tel:
+        print(f"  telemetry: zoom_med={zoom:.2f} leash={tel.get('leash_pct', 0):.0f}% "
+              f"corr_mean={tel.get('corr_deg_mean', 0):.2f}deg  phase-corr good {good}/{total}")
+
+    ledger = args.ledger or session.parent / "eis_progress.csv"
+    new = not ledger.exists()
+    with open(ledger, "a", newline="") as f:
+        w = csv.writer(f)
+        if new:
+            w.writerow(["session", "label", "gyro_rms_dps", "video_rms_px", "zoom_med", "leash_pct"]
+                       + [f"in_{b[0]}_{b[1]}" for b in BANDS]
+                       + [f"res_{b[0]}_{b[1]}" for b in BANDS]
+                       + [f"ratio_{b[0]}_{b[1]}" for b in BANDS])
+        w.writerow([session.name, args.label, f"{gin_rms:.2f}", f"{vres_rms:.3f}",
+                    f"{zoom:.2f}", f"{tel.get('leash_pct', 0):.1f}"]
+                   + [f"{gin[b]:.3f}" for b in BANDS]
+                   + [f"{vres[b]:.3f}" for b in BANDS]
+                   + [f"{supp[b]:.3f}" for b in BANDS])
+    print(f"  → appended to {ledger}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/eis_progress.py
+++ b/tools/eis_progress.py
@@ -25,6 +25,7 @@ ANALYSIS_H, ANALYSIS_W = 480, 270  # portrait 4K downscale
 def band_rms(sig, fs):
     sig = np.asarray(sig, dtype=np.float64)
     sig = sig - sig.mean()
+    sig = sig * np.hanning(len(sig))  # window the series — raw FFT leaks across bands
     f = np.fft.rfftfreq(len(sig), 1 / fs)
     p = np.abs(np.fft.rfft(sig)) ** 2 / len(sig)
     return {b: float(np.sqrt(p[(f >= b[0]) & (f < b[1])].sum())) for b in BANDS}

--- a/tools/validate_meter.py
+++ b/tools/validate_meter.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Phase 0: validate the eis_progress measurement chain against known ground truth.
+
+Measures a real capture twice — as-is, and with a KNOWN synthetic displacement
+(sum of sinusoids) warped onto each frame — through the exact phase-correlation
+band measurement used by eis_progress.py. The injected signal must be recovered
+as the band-power difference (injected and real motion are independent).
+
+Usage: .venv/bin/python validate_meter.py <video.mp4>
+"""
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+BANDS = [(0.2, 1), (1, 3), (3, 8), (8, 15)]
+FPS = 30.0
+N_FRAMES = 600
+
+# injected shake: (freq Hz, amplitude px at 480p) per axis
+INJECT_U = [(2.0, 6.0), (10.0, 2.0)]
+INJECT_V = [(5.0, 4.0)]
+
+
+def injected_series(comps, n):
+    t = np.arange(n) / FPS
+    return sum(a * np.sin(2 * np.pi * f * t) for f, a in comps)
+
+
+def band_power(sig, fs):
+    sig = np.asarray(sig, dtype=np.float64)
+    sig = sig - sig.mean()
+    sig = sig * np.hanning(len(sig))  # window the series — raw FFT leaks across bands
+    f = np.fft.rfftfreq(len(sig), 1 / fs)
+    p = np.abs(np.fft.rfft(sig)) ** 2 / len(sig)
+    return {b: float(p[(f >= b[0]) & (f < b[1])].sum()) for b in BANDS}
+
+
+def measure(video, pos_u=None, pos_v=None):
+    cap = cv2.VideoCapture(str(video))
+    hann = None
+    prev = None
+    meas = []
+    i = 0
+    while i < N_FRAMES:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        g = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        g = cv2.resize(g, (270, 480)).astype(np.float32)
+        if pos_u is not None:
+            m = np.float32([[1, 0, pos_u[i]], [0, 1, pos_v[i]]])
+            g = cv2.warpAffine(g, m, (270, 480), borderMode=cv2.BORDER_REPLICATE)
+        crop = g[60:420, 35:235]
+        if hann is None:
+            hann = cv2.createHanningWindow((crop.shape[1], crop.shape[0]), cv2.CV_32F)
+        crop = crop * hann
+        if prev is not None:
+            (du, dv), resp = cv2.phaseCorrelate(prev, crop)
+            meas.append((du, dv, resp))
+        prev = crop
+        i += 1
+    cap.release()
+    return np.array(meas)
+
+
+def main():
+    video = Path(sys.argv[1])
+    pos_u = injected_series(INJECT_U, N_FRAMES)
+    pos_v = injected_series(INJECT_V, N_FRAMES)
+
+    base = measure(video)
+    warped = measure(video, pos_u, pos_v)
+    n = min(len(base), len(warped))
+    gt_u = np.diff(pos_u[: n + 1])
+    gt_v = np.diff(pos_v[: n + 1])
+
+    print(f"frames: {n}, response med base={np.median(base[:,2]):.3f} warped={np.median(warped[:,2]):.3f}")
+    ok = True
+    for axis, col, gt in (("u", 0, gt_u), ("v", 1, gt_v)):
+        pb = band_power(base[:n, col], FPS)
+        pw = band_power(warped[:n, col], FPS)
+        pg = band_power(gt, FPS)
+        print(f"  {axis}-axis (recovered vs injected, band-power difference):")
+        for b in BANDS:
+            if pg[b] < 0.01:
+                continue
+            rec = np.sqrt(max(pw[b] - pb[b], 0.0))
+            inj = np.sqrt(pg[b])
+            ratio = rec / inj
+            flag = "OK" if 0.85 <= ratio <= 1.15 else "FAIL"
+            if flag == "FAIL":
+                ok = False
+            print(f"    {b[0]}-{b[1]}Hz: injected={inj:.3f}px recovered={rec:.3f}px ratio={ratio:.3f} {flag}")
+    print("\nMETER VALID" if ok else "\nMETER INVALID — do not trust band numbers")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Replace per-frame one-shot vibrations with a coroutine-driven heartbeat loop
- Pulse rate (900ms→180ms) and amplitude (20→180) encode centering quality
- Single pulse = horizontal drift, double pulse = vertical drift (axis hint)
- Lost/searching: distinct slow double-tap every 1.5s
- Dead zone 0.05, full urgency by 0.50 — tuned for zoomed subjects

## Test plan
- [ ] Lock on object centered → feel slow gentle pulses (~1Hz)
- [ ] Pan horizontally off-center → single pulses speed up
- [ ] Pan vertically off-center → double pulses speed up
- [ ] Near frame edge → rapid strong pulses
- [ ] Lose tracking → distinct slow double-tap pattern
- [ ] Clear tracking → silence
- [ ] With auto-zoom active, verify feedback reacts before target reaches edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)